### PR TITLE
Use params instead of body for the reset token

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -72,7 +72,8 @@ const sendResetPasswordEmail = async (req, res) => {
 }
 
 const updatePassword = async (req, res) => {
-  const { password, resetToken } = req.body
+  const { password } = req.body
+  const resetToken = req.params.token
 
   await authService.updatePassword(resetToken, password)
 

--- a/docs/auth/auth-schema.yaml
+++ b/docs/auth/auth-schema.yaml
@@ -9,10 +9,10 @@ definitions:
             type: string
             example: John
           lastName:
-            type: string    
+            type: string
             example: Doe
           email:
-            type: string    
+            type: string
             example: johndoe@gmail.com
           id:
             type: string
@@ -21,7 +21,7 @@ definitions:
     type: object
     properties:
       email:
-        type: string    
+        type: string
         example: johndoe@gmail.com
       password:
         type: string
@@ -44,12 +44,6 @@ definitions:
       password:
         type: string
         example: qwer1234
-  resetToken:
-    type: object
-    properties:
-      resetToken:
-        type: string
-        example: 348dasas9209a0d9asd09asd09asd09
   accessToken:
     type: object
     properties:

--- a/docs/auth/auth.yaml
+++ b/docs/auth/auth.yaml
@@ -78,7 +78,7 @@ paths:
                 code: 'EMAIL_NOT_FOUND'
                 message: 'There is no user registered with that email.'
 
-  /auth/reset-password:
+  /auth/reset-password/{token}:
     patch:
       tags:
         - Auth
@@ -86,13 +86,17 @@ paths:
       description: Checks the reset token for validity, and updates the password
       produces:
         - application/json
+      parameters:
+        - name: token
+          in: path
+          required: true
+          description: Reset Token
+          type: string
       requestBody:
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/definitions/resetToken'
-                - $ref: '#/definitions/resetPassword'
+              $ref: '#/definitions/resetPassword'
       responses:
         204:
           description: Successful completion of an update
@@ -159,7 +163,7 @@ paths:
           description: Access token has been successfully refreshed
           headers:
             Set-Cookie:
-              schema: 
+              schema:
                 type: string
                 example: refreshToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.GUiOiJzdHVkZW50IiwiaXNatalXJzdExvZ2luIjpQiOjE2NjA5Mjg4ODMsImV4cCI6MWomanzMjQ4M30.gn_hJqB9zVi5Ux5oRu22hGQ9W4z2njkdnx4Od8NXeDM; Max-Age=86400; Domain=s2s-back-stage.azurewebsites.net; Path=/; Expires=Sat, 20 Aug 2022 17:32:57 GMT; HttpOnly; Secure; SameSite=None
           content:

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -21,7 +21,7 @@ router.post(
   asyncWrapper(authController.sendResetPasswordEmail)
 )
 router.patch(
-  '/reset-password',
+  '/reset-password/:token',
   validationMiddleware(resetPasswordValidationSchema),
   asyncWrapper(authController.updatePassword)
 )

--- a/validation/schemas/resetPassword.js
+++ b/validation/schemas/resetPassword.js
@@ -4,10 +4,6 @@ const {
 } = require('~/consts/validation')
 
 const resetPasswordValidationSchema = {
-  resetToken: {
-    type: 'string',
-    required: true
-  },
   password: {
     type: 'string',
     required: true,


### PR DESCRIPTION
Refactored the `/reset-password` endpoint to use params instead of the request body for the reset token.