### PR TITLE
logout returns 204, fixed tests

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -10,7 +10,7 @@ const {
 const COOKIE_OPTIONS = {
   maxAge: oneDayInMs,
   httpOnly: true,
-  secure: true,
+  secure: process.env.NODE_ENV === 'production',
   sameSite: 'none',
   domain: COOKIE_DOMAIN
 }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -39,10 +39,10 @@ const login = async (req, res) => {
 const logout = async (req, res) => {
   const { refreshToken } = req.cookies
 
-  const logoutInfo = await authService.logout(refreshToken)
+  await authService.logout(refreshToken)
   res.clearCookie(REFRESH_TOKEN)
 
-  res.status(200).json(logoutInfo)
+  res.status(204).end()
 }
 
 const confirmEmail = async (req, res) => {

--- a/services/auth.js
+++ b/services/auth.js
@@ -58,9 +58,7 @@ const authService = {
   },
 
   logout: async (refreshToken) => {
-    const deleteInfo = await tokenService.removeRefreshToken(refreshToken)
-
-    return deleteInfo
+    await tokenService.removeRefreshToken(refreshToken)
   },
 
   confirmEmail: async (confirmToken) => {

--- a/test/integration/controllers/auth.spec.js
+++ b/test/integration/controllers/auth.spec.js
@@ -152,8 +152,7 @@ describe('Auth controller', () => {
     it('should logout user', async () => {
       const response = await app.post('/auth/logout').set('Cookie', `refreshToken=${refreshToken}`)
 
-      expect(response.statusCode).toBe(200)
-      expect(response.body).toEqual({ deletedCount: 1 })
+      expect(response.statusCode).toBe(204)
     })
   })
 


### PR DESCRIPTION
made logout method return 204
updated tests
fixed cookie options: 
`secure` option is set to `false` now (for tests - http/postman) and will be changed to `true` when `'production'` (cookie will be sent on an encrypted connection - https)