### PR TITLE
feature/delete-account-endpoint

### DIFF
--- a/consts/errors.js
+++ b/consts/errors.js
@@ -126,6 +126,10 @@ const errors = {
   OFFER_NOT_FOUND: {
     code: 'OFFER_NOT_FOUND',
     message: 'Offer with provided data was not found.'
+  },
+  USER_DEACTIVATED: {
+    code: 'USER_DEACTIVATED',
+    message: 'User with the specified id was deactivated.'
   }
 }
 

--- a/consts/validation.js
+++ b/consts/validation.js
@@ -16,7 +16,7 @@ const enums = {
   SPOKEN_LANG_ENUM: ['English', 'Ukrainian', 'Polish', 'German', 'French', 'Spanish', 'Arabic'],
   SUBJECT_LEVEL_ENUM: ['Beginner', 'Intermediate', 'Advanced', 'Test Preparation', 'Professional'],
   ROLE_ENUM: ['student', 'tutor', 'admin'],
-  STATUS_ENUM: ['active', 'blocked']
+  STATUS_ENUM: ['active', 'blocked', 'deactived']
 }
 
 module.exports = {

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -25,8 +25,17 @@ const deleteUser = async (req, res) => {
   res.status(204).end()
 }
 
+const userDeactivation = async (req, res) => {
+  const { id } = req.params
+
+  const user = await userService.userStatusChange(id)
+
+  res.status(200).json(user)
+}
+
 module.exports = {
   getUsers,
   getOneUser,
-  deleteUser
+  deleteUser,
+  userDeactivation
 }

--- a/routes/user.js
+++ b/routes/user.js
@@ -14,5 +14,6 @@ router.use('/:id/:role/reviews', reviewRouter)
 router.get('/', asyncWrapper(userController.getUsers))
 router.get('/:id/:role', asyncWrapper(userController.getOneUser))
 router.delete('/:id', asyncWrapper(userController.deleteUser))
+router.post('/:id/deactivation', asyncWrapper(userController.userDeactivation))
 
 module.exports = router


### PR DESCRIPTION
add an endpoint that will allow a user to 'delete' his/her account, but basically it will change the status from active to deactivated
and accounts with status: deactivated must be not visible via query
call this endpoint the way you think is the best, something like /delete-my-profile or /my-profile-delete or /delete-me
but follow the same schema as update the current user account

use middleware setcurruserIdandRole for it