### PR TITLE
Fix middleware naming in cooperation route

### DIFF
--- a/routes/cooperation.js
+++ b/routes/cooperation.js
@@ -4,7 +4,7 @@ const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
 const { authMiddleware } = require('~/middlewares/auth')
 const cooperationController = require('~/controllers/cooperation')
-const setCurrentUserId = require('~/middlewares/setCurrentUserId')
+const setCurrentUserIdAndRole = require('~/middlewares/setCurrentUserIdAndRole')
 
 const router = express.Router()
 
@@ -13,7 +13,7 @@ router.use(authMiddleware)
 router.param('id', idValidation)
 
 router.get('/', asyncWrapper(cooperationController.getCooperations))
-router.post('/', setCurrentUserId, asyncWrapper(cooperationController.createCooperation))
+router.post('/', setCurrentUserIdAndRole, asyncWrapper(cooperationController.createCooperation))
 router.get('/:id', asyncWrapper(cooperationController.getCooperationById))
 router.patch('/:id', asyncWrapper(cooperationController.updateCooperation))
 


### PR DESCRIPTION
A little fix in routing for cooperation