### PR TITLE
added nested route for offers

### DIFF
--- a/consts/errors.js
+++ b/consts/errors.js
@@ -7,14 +7,6 @@ const errors = {
     code: 'USER_NOT_FOUND',
     message: 'User with the specified email or id was not found.'
   },
-  USER_ALREADY_BLOCKED: {
-    code: 'USER_ALREADY_BLOCKED',
-    message: 'User with the specified id is already blocked.'
-  },
-  USER_ALREADY_UNBLOCKED: {
-    code: 'USER_ALREADY_UNBLOCKED',
-    message: 'User with the specified id is already unblocked.'
-  },
   INCORRECT_CREDENTIALS: {
     code: 'INCORRECT_CREDENTIALS',
     message: 'The password you entered is incorrect.'
@@ -111,30 +103,14 @@ const errors = {
     code: 'INVALID_LANGUAGE',
     message: `The language name is invalid. Possible options: ${APP_LANG_ENUM.join(', ')}.`
   },
-  REVIEW_NOT_FOUND: {
-    code: 'REVIEW_NOT_FOUND',
-    message: 'Review with the specified id was not found.'
-  },
-  SUBJECT_NOT_FOUND: {
-    code: 'SUBJECT_NOT_FOUND',
-    message: 'Subject with the specified id was not found.'
-  },
   SUBJECT_ALREADY_EXISTS: {
     code: 'SUBJECT_ALREADY_EXISTS',
     message: 'Subject with the specified name already exists.'
   },
-  OFFER_NOT_FOUND: {
-    code: 'OFFER_NOT_FOUND',
-    message: 'Offer with provided data was not found.'
-  },
-  CATEGORY_NOT_FOUND: {
-    code: 'CATEGORY_NOT_FOUND',
-    message: 'Category with provided id was not found.'
-  },
-  COOPERATION_NOT_FOUND: {
-    code: 'COOPERATION_NOT_FOUND',
-    message: 'Cooperation with the specified id was not found.'
-  }
+  DOCUMENT_NOT_FOUND: (document) => ({
+    code: 'DOCUMENT_NOT_FOUND',
+    message: `${document} with the specified id was not found`
+  })
 }
 
 const validationErrors = {

--- a/consts/errors.js
+++ b/consts/errors.js
@@ -5,7 +5,7 @@ const {
 const errors = {
   USER_NOT_FOUND: {
     code: 'USER_NOT_FOUND',
-    message: 'User with the specified email or id was not found.'
+    message: 'User with the specified email was not found.'
   },
   INCORRECT_CREDENTIALS: {
     code: 'INCORRECT_CREDENTIALS',
@@ -74,10 +74,6 @@ const errors = {
   TEMPLATE_NOT_FOUND: {
     code: 'TEMPLATE_NOT_FOUND',
     message: 'The requested template was not found.'
-  },
-  EMAIL_NOT_FOUND: {
-    code: 'EMAIL_NOT_FOUND',
-    message: 'There is no user registered with that email.'
   },
   BAD_RESET_TOKEN: {
     code: 'BAD_RESET_TOKEN',

--- a/consts/validation.js
+++ b/consts/validation.js
@@ -19,7 +19,8 @@ const enums = {
   LOGIN_ROLE_ENUM: ['student', 'tutor', 'admin'],
   AUTHOR_ROLE_ENUM: ['student', 'tutor'],
   STATUS_ENUM: ['active', 'blocked'],
-  COOPERATION_STATUS: ['pending', 'active', 'declined', 'closed']
+  COOPERATION_STATUS: ['pending', 'active', 'declined', 'closed'],
+  PARAMS: ['id', 'categoryId', 'subjectId']
 }
 
 module.exports = {

--- a/controllers/offer.js
+++ b/controllers/offer.js
@@ -1,7 +1,13 @@
 const offerService = require('~/services/offer')
 
 const getOffers = async (req, res) => {
-  const offers = await offerService.getOffers()
+  const { catId, subId } = req.params
+
+  const filters = {}
+  if (catId) filters.categoryId = catId
+  if (subId) filters.subjectId = subId
+
+  const offers = await offerService.getOffers(filters)
 
   res.status(200).json(offers)
 }

--- a/controllers/offer.js
+++ b/controllers/offer.js
@@ -1,13 +1,12 @@
 const offerService = require('~/services/offer')
+const getMatchOptions = require('~/utils/getMatchOptions')
 
 const getOffers = async (req, res) => {
-  const { catId, subId } = req.params
+  const { categoryId, subjectId } = req.params
 
-  const filters = {}
-  if (catId) filters.categoryId = catId
-  if (subId) filters.subjectId = subId
+  const match = getMatchOptions({ categoryId, subjectId })
 
-  const offers = await offerService.getOffers(filters)
+  const offers = await offerService.getOffers(match)
 
   res.status(200).json(offers)
 }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -23,6 +23,7 @@ const updateUser = async (req, res) => {
   const updateData = req.body
 
   await userService.updateUser(id, updateData)
+
   res.status(204).end()
 }
 

--- a/docs/auth/auth.yaml
+++ b/docs/auth/auth.yaml
@@ -154,8 +154,8 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: 'EMAIL_NOT_FOUND'
-                message: 'There is no user registered with that email.'
+                code: 'USER_NOT_FOUND'
+                message: 'User with the specified email was not found.'
   /auth/reset-password/{token}:
     patch:
       tags:

--- a/docs/category/category.yaml
+++ b/docs/category/category.yaml
@@ -2,7 +2,7 @@ paths:
   /categories:
     get:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Categories
       summary: Find all categories
@@ -107,7 +107,7 @@ paths:
   /categories/{id}:
     get:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Categories
       summary: Find category by ID
@@ -162,5 +162,5 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: CATEGORY_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Category with the specified id was not found.

--- a/docs/cooperation/cooperation.yaml
+++ b/docs/cooperation/cooperation.yaml
@@ -2,7 +2,7 @@ paths:
   /cooperations:
     get:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Reviews
       summary: Find all cooperations
@@ -45,7 +45,7 @@ paths:
                 message: 'The requested URL requires user authorization.'
     post:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Cooperations
       summary: Create new cooperation.
@@ -103,7 +103,7 @@ paths:
   /cooperations/{id}:
     get:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Cooperations
       summary: Find cooperation by ID
@@ -160,11 +160,11 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: COOPERATION_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Cooperation with the specified id was not found.
     patch:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Cooperations
       summary: Update cooperation by ID
@@ -218,5 +218,5 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: COOPERATION_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Cooperation with the specified id was not found.

--- a/docs/offer/offer.yaml
+++ b/docs/offer/offer.yaml
@@ -2,7 +2,7 @@ paths:
   /offers:
     get:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Offers
       summary: Find all offers
@@ -47,7 +47,7 @@ paths:
                 message: The requested URL requires user authorization.
     post:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Offers
       summary: Create new offer.
@@ -65,7 +65,7 @@ paths:
               price: 300,
               proficiencyLevel: Advanced
               description: this is a new 123123123123123 text
-              languages: [ English , Ukrainian ]
+              languages: [English, Ukrainian]
               subjectId: 63da8767c9ad4c9a0b0eacd3
               categoryId: 63525e23bf163f5ea609ff2b
               isActive: false
@@ -80,10 +80,7 @@ paths:
                 price: 300
                 proficiencyLevel: Advanced
                 description: this is a new 123123123123123 text
-                languages: [
-                    English,
-                    Ukrainian
-                ]
+                languages: [English, Ukrainian]
                 authorRole: tutor
                 userId": 63e63bb04d1bf3bea00e3d88
                 subjectId: 63da8767c9ad4c9a0b0eacd3
@@ -115,7 +112,7 @@ paths:
   /offers/{id}:
     get:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Offers
       summary: Find and return offer by ID
@@ -140,10 +137,7 @@ paths:
                 price: 300,
                 proficiencyLevel: Advanced
                 description: this is a new 123123123123123 text
-                languages: [
-                    English,
-                    Ukrainian
-                ]
+                languages: [English, Ukrainian]
                 authorRole: tutor
                 userId: 63e63bb04d1bf3bea00e3d88
                 subjectId: 63da8767c9ad4c9a0b0eacd3
@@ -178,11 +172,11 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: OFFER_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Offer with provided data was not found.
     patch:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Offers
       summary: Find and update offer by ID
@@ -206,7 +200,7 @@ paths:
               price: 300,
               proficiencyLevel: Advanced
               description: this is a test text 123
-              languages: [ Ukrainian, Polish ]
+              languages: [Ukrainian, Polish]
               subjectId: 63da8767c9ad4c9a0b0eacd3
               categoryId: 63525e23bf163f5ea609ff2b
       responses:
@@ -250,11 +244,11 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: OFFER_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Offer with provided data was not found.
     delete:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Offers
       summary: Find and delete offer by ID
@@ -308,5 +302,5 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: OFFER_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Offer with provided data was not found.

--- a/docs/offer/offer.yaml
+++ b/docs/offer/offer.yaml
@@ -173,7 +173,7 @@ paths:
               example:
                 status: 404
                 code: DOCUMENT_NOT_FOUND
-                message: Offer with provided data was not found.
+                message: Offer with the specified id was not found.
     patch:
       security:
         - bearerAuth: []
@@ -245,7 +245,7 @@ paths:
               example:
                 status: 404
                 code: DOCUMENT_NOT_FOUND
-                message: Offer with provided data was not found.
+                message: Offer with the specified id was not found.
     delete:
       security:
         - bearerAuth: []
@@ -303,4 +303,4 @@ paths:
               example:
                 status: 404
                 code: DOCUMENT_NOT_FOUND
-                message: Offer with provided data was not found.
+                message: Offer with the specified id was not found.

--- a/docs/review/review.yaml
+++ b/docs/review/review.yaml
@@ -299,7 +299,7 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: REVIEW_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Review with the specified id was not found.
     patch:
       security:
@@ -367,7 +367,7 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: REVIEW_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Review with the specified id was not found.
     delete:
       security:
@@ -425,5 +425,5 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: REVIEW_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Review with the specified id was not found.

--- a/docs/subject/subject.yaml
+++ b/docs/subject/subject.yaml
@@ -22,7 +22,7 @@ paths:
                   category: 63525e23bf163f5ea609ff27
                   totalOffers: 2167
                   createdAt: 2023-20-01T13:25:36.292Z
-                  updatedAt: 2023-20-01T13:25:36.292Z                  
+                  updatedAt: 2023-20-01T13:25:36.292Z
                 - _id: 6255bc080a71adf9223df135
                   name: Algebra
                   category: 63525e23bf163f5ea609ff29
@@ -160,7 +160,7 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: SUBJECT_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Subject with the specified id was not found.
     patch:
       security:
@@ -229,7 +229,7 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: SUBJECT_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Subject with the specified id was not found.
     delete:
       security:
@@ -287,5 +287,5 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: SUBJECT_NOT_FOUND
+                code: DOCUMENT_NOT_FOUND
                 message: Subject with the specified id was not found.

--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -104,7 +104,10 @@ paths:
                   lastName: Doe
                   email: johndoe@gmail.com
                   categories:
-                    [{ _id: 6255bc080a75adf9223df444, name: Languages }, { _id: 6255bc080a75adf443d7644, name: Biology }]
+                    [
+                      { _id: 6255bc080a75adf9223df444, name: Languages },
+                      { _id: 6255bc080a75adf443d7644, name: Biology }
+                    ]
                   totalReviews: { student: 10, tutor: 0 }
                   averageRating: { student: 4.5, tutor: 0 }
                   nativeLanguage: english
@@ -118,9 +121,7 @@ paths:
                   bookmarkedOffers: []
                   createdAt: 2021-04-09T11:34:53.243+00:00
                   updatedAt: 2022-09-02T11:59:53.243+00:00
-                  reviewStats: {
-                      stats: [ { rating: 4, count: 5 }, { rating: 5, count: 5 } ]
-                  }
+                  reviewStats: { stats: [{ rating: 4, count: 5 }, { rating: 5, count: 5 }] }
                 example2:
                   _id: 6255bc080a75adf9223df100
                   role: student
@@ -128,7 +129,10 @@ paths:
                   lastName: Doe
                   email: johndoe@gmail.com
                   categories:
-                    [ { _id: 6255bc080a75adf9223df444, name: Languages }, { _id: 6255bc080a75adf443d7644, name: Biology } ]
+                    [
+                      { _id: 6255bc080a75adf9223df444, name: Languages },
+                      { _id: 6255bc080a75adf443d7644, name: Biology }
+                    ]
                   totalReviews: { student: 10, tutor: 0 }
                   averageRating: { student: 4.5, tutor: 0 }
                   nativeLanguage: english
@@ -171,13 +175,13 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: 'USER_NOT_FOUND'
-                message: 'User with the specified email or id was not found.'
+                code: 'DOCUMENT_NOT_FOUND'
+                message: 'User with the specified id was not found.'
     patch:
       security:
         - bearerAuth: []
         - role:
-          - admin
+            - admin
       tags:
         - Users
       summary: Find and update user status by ID
@@ -197,8 +201,7 @@ paths:
           application/json:
             schema:
               $ref: '#/definitions/user'
-            example:
-              status:'active'
+            example: status:'active'
       responses:
         204:
           description: No Content
@@ -240,8 +243,8 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: 'USER_NOT_FOUND'
-                message: 'User with the specified email or id was not found.'
+                code: 'DOCUMENT_NOT_FOUND'
+                message: 'User with the specified id was not found.'
     delete:
       security:
         - bearerAuth: []
@@ -300,12 +303,12 @@ paths:
                 $ref: '#/components/Error'
               example:
                 status: 404
-                code: 'USER_NOT_FOUND'
-                message: 'User with the specified email or id was not found.'
+                code: 'DOCUMENT_NOT_FOUND'
+                message: 'User with the specified id was not found.'
   /users/my-profile:
     get:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Users
       summary: Find information about current user`s profile
@@ -326,7 +329,7 @@ paths:
                 lastName: Doe
                 email: johndoe@gmail.com
                 categories:
-                  [ { _id: 6255bc080a75adf9223df444, name: Languages }, { _id: 6255bc080a75adf443d7644, name: Biology } ]
+                  [{ _id: 6255bc080a75adf9223df444, name: Languages }, { _id: 6255bc080a75adf443d7644, name: Biology }]
                 totalReviews: { student: 10, tutor: 0 }
                 averageRating: { student: 4.5, tutor: 0 }
                 nativeLanguage: english
@@ -337,19 +340,9 @@ paths:
                 isEmailConfirmed: true
                 isFirstLogin: true
                 lastLogin: 2022-09-02T11:59:53.243+00:00
-                bookmarkedOffers: [ ]
+                bookmarkedOffers: []
                 createdAt: 2021-04-09T11:34:53.243+00:00
                 updatedAt: 2022-09-02T11:59:53.243+00:00
-        400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/Error'
-              example:
-                status: 400
-                code: 'INVALID_ID'
-                message: 'ID is invalid.'
         401:
           description: Unauthorized
           content:
@@ -360,20 +353,10 @@ paths:
                 status: 404
                 code: 'UNAUTHORIZED'
                 message: 'The requested URL requires user authorization.'
-        404:
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/Error'
-              example:
-                status: 404
-                code: 'USER_NOT_FOUND'
-                message: 'User with the specified email or id was not found.'
   /users/{id}/reviews:
     get:
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       tags:
         - Users
       summary: Find all reviews for a user with the specified ID and role
@@ -460,6 +443,16 @@ paths:
                         name: languages
                     createdAt: 2022-10-18T13:25:36.292Z
                     updatedAt: 2022-10-18T13:25:36.292Z
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/Error'
+              example:
+                status: 400
+                code: 'INVALID_ID'
+                message: 'ID is invalid.'
         401:
           description: Unauthorized
           content:
@@ -470,3 +463,13 @@ paths:
                 status: 401
                 code: 'UNAUTHORIZED'
                 message: 'The requested URL requires user authorization.'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/Error'
+              example:
+                status: 404
+                code: 'DOCUMENT_NOT_FOUND'
+                message: 'User with the specified id was not found.'

--- a/middlewares/entityValidation.js
+++ b/middlewares/entityValidation.js
@@ -1,0 +1,24 @@
+const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
+const { createError } = require('~/utils/errorsHelper')
+
+const isEntityValid = (entities) => {
+  return async (req, res, next) => {
+    if (!req.params) next()
+
+    for (const { model, idName } of entities) {
+      const id = req.params[idName]
+
+      if (id) {
+        console.log('model', model)
+        console.log('modelName', model.modelName)
+        const document = await model.findById(id)
+        if (!document) {
+          next(createError(404, DOCUMENT_NOT_FOUND(model.modelName)))
+        }
+      }
+    }
+
+    next()
+  }
+}
+module.exports = isEntityValid

--- a/middlewares/entityValidation.js
+++ b/middlewares/entityValidation.js
@@ -9,8 +9,6 @@ const isEntityValid = (entities) => {
       const id = req.params[idName]
 
       if (id) {
-        console.log('model', model)
-        console.log('modelName', model.modelName)
         const document = await model.findById(id)
         if (!document) {
           next(createError(404, DOCUMENT_NOT_FOUND(model.modelName)))

--- a/middlewares/entityValidation.js
+++ b/middlewares/entityValidation.js
@@ -3,20 +3,20 @@ const { createError } = require('~/utils/errorsHelper')
 
 const isEntityValid = (entities) => {
   return async (req, res, next) => {
-    if (!req.params) next()
-
     for (const { model, idName } of entities) {
       const id = req.params[idName]
 
-      if (id) {
-        const document = await model.findById(id)
-        if (!document) {
-          next(createError(404, DOCUMENT_NOT_FOUND(model.modelName)))
-        }
+      if (!id) continue
+
+      const document = await model.findById(id)
+
+      if (!document) {
+        next(createError(404, DOCUMENT_NOT_FOUND(model.modelName)))
       }
     }
 
     next()
   }
 }
+
 module.exports = isEntityValid

--- a/models/user.js
+++ b/models/user.js
@@ -144,7 +144,4 @@ const userSchema = new Schema(
   }
 )
 
-// TODO:
-// coops(virtuals)
-
 module.exports = model(USER, userSchema)

--- a/routes/category.js
+++ b/routes/category.js
@@ -35,6 +35,6 @@ router.use('/:id/subjects', isEntityValid([{ model: Category, idName: 'id' }]), 
 
 router.get('/', asyncWrapper(categoryController.getCategories))
 router.get('/names', asyncWrapper(categoryController.getCategoriesNames))
-router.get('/:id', asyncWrapper(categoryController.getCategoryById))
+router.get('/:id', isEntityValid([{ model: Category, idName: 'id' }]), asyncWrapper(categoryController.getCategoryById))
 
 module.exports = router

--- a/routes/category.js
+++ b/routes/category.js
@@ -23,7 +23,6 @@ PARAMS.forEach((param) => {
   router.param(param, idValidation)
 })
 
-router.use('/:id/subjects', subjectRouter)
 router.use(
   '/:categoryId?/subjects/:subjectId?/offers',
   isEntityValid([
@@ -32,6 +31,7 @@ router.use(
   ]),
   offerRouter
 )
+router.use('/:id/subjects', subjectRouter)
 
 router.get('/', asyncWrapper(categoryController.getCategories))
 router.get('/names', asyncWrapper(categoryController.getCategoriesNames))

--- a/routes/category.js
+++ b/routes/category.js
@@ -3,8 +3,10 @@ const express = require('express')
 const { authMiddleware } = require('~/middlewares/auth')
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
+
 const categoryController = require('~/controllers/category')
 const subjectRouter = require('~/routes/subject')
+const offerRouter = require('~/routes/offer')
 
 const router = express.Router()
 
@@ -14,13 +16,10 @@ router.param('id', idValidation)
 
 router.use('/:id/subjects', subjectRouter)
 
+router.use('/:catId?/subjects/:subId?/offers', offerRouter)
+
 router.get('/', asyncWrapper(categoryController.getCategories))
 router.get('/names', asyncWrapper(categoryController.getCategoriesNames))
 router.get('/:id', asyncWrapper(categoryController.getCategoryById))
-
-//TODO: must be done after offers and cooperations logic
-//router.post('/', asyncWrapper(categoryController.addCategory))
-//router.patch('/:id', asyncWrapper(categoryController.updateCategory))
-//router.delete('/:id', asyncWrapper(categoryController.deleteCategory))
 
 module.exports = router

--- a/routes/category.js
+++ b/routes/category.js
@@ -3,20 +3,35 @@ const express = require('express')
 const { authMiddleware } = require('~/middlewares/auth')
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
+const isEntityValid = require('~/middlewares/entityValidation')
 
 const categoryController = require('~/controllers/category')
 const subjectRouter = require('~/routes/subject')
 const offerRouter = require('~/routes/offer')
+const {
+  enums: { PARAMS }
+} = require('~/consts/validation')
+
+const Category = require('~/models/category')
+const Subject = require('~/models/subject')
 
 const router = express.Router()
 
 router.use(authMiddleware)
 
-router.param('id', idValidation)
+PARAMS.forEach((param) => {
+  router.param(param, idValidation)
+})
 
 router.use('/:id/subjects', subjectRouter)
-
-router.use('/:catId?/subjects/:subId?/offers', offerRouter)
+router.use(
+  '/:categoryId?/subjects/:subjectId?/offers',
+  isEntityValid([
+    { model: Category, idName: 'categoryId' },
+    { model: Subject, idName: 'subjectId' }
+  ]),
+  offerRouter
+)
 
 router.get('/', asyncWrapper(categoryController.getCategories))
 router.get('/names', asyncWrapper(categoryController.getCategoriesNames))

--- a/routes/category.js
+++ b/routes/category.js
@@ -31,7 +31,7 @@ router.use(
   ]),
   offerRouter
 )
-router.use('/:id/subjects', subjectRouter)
+router.use('/:id/subjects', isEntityValid([{ model: Category, idName: 'id' }]), subjectRouter)
 
 router.get('/', asyncWrapper(categoryController.getCategories))
 router.get('/names', asyncWrapper(categoryController.getCategoriesNames))

--- a/routes/cooperation.js
+++ b/routes/cooperation.js
@@ -3,8 +3,11 @@ const express = require('express')
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
 const { authMiddleware } = require('~/middlewares/auth')
-const cooperationController = require('~/controllers/cooperation')
 const setCurrentUserIdAndRole = require('~/middlewares/setCurrentUserIdAndRole')
+const isEntityValid = require('~/middlewares/entityValidation')
+
+const cooperationController = require('~/controllers/cooperation')
+const Cooperation = require('~/models/cooperation')
 
 const router = express.Router()
 
@@ -14,7 +17,15 @@ router.param('id', idValidation)
 
 router.get('/', asyncWrapper(cooperationController.getCooperations))
 router.post('/', setCurrentUserIdAndRole, asyncWrapper(cooperationController.createCooperation))
-router.get('/:id', asyncWrapper(cooperationController.getCooperationById))
-router.patch('/:id', asyncWrapper(cooperationController.updateCooperation))
+router.get(
+  '/:id',
+  isEntityValid([{ model: Cooperation, idName: 'id' }]),
+  asyncWrapper(cooperationController.getCooperationById)
+)
+router.patch(
+  '/:id',
+  isEntityValid([{ model: Cooperation, idName: 'id' }]),
+  asyncWrapper(cooperationController.updateCooperation)
+)
 
 module.exports = router

--- a/routes/offer.js
+++ b/routes/offer.js
@@ -6,7 +6,7 @@ const offerController = require('~/controllers/offer')
 const { authMiddleware } = require('~/middlewares/auth')
 const setCurrentUserIdAndRole = require('~/middlewares/setCurrentUserIdAndRole')
 
-const router = express.Router()
+const router = express.Router({ mergeParams: true })
 
 router.use(authMiddleware)
 

--- a/routes/offer.js
+++ b/routes/offer.js
@@ -2,9 +2,12 @@ const express = require('express')
 
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
-const offerController = require('~/controllers/offer')
 const { authMiddleware } = require('~/middlewares/auth')
 const setCurrentUserIdAndRole = require('~/middlewares/setCurrentUserIdAndRole')
+const isEntityValid = require('~/middlewares/entityValidation')
+
+const offerController = require('~/controllers/offer')
+const Offer = require('~/models/offer')
 
 const router = express.Router({ mergeParams: true })
 
@@ -14,8 +17,8 @@ router.param('id', idValidation)
 
 router.get('/', asyncWrapper(offerController.getOffers))
 router.post('/', setCurrentUserIdAndRole, asyncWrapper(offerController.createOffer))
-router.get('/:id', asyncWrapper(offerController.getOfferById))
-router.patch('/:id', asyncWrapper(offerController.updateOffer))
-router.delete('/:id', asyncWrapper(offerController.deleteOffer))
+router.get('/:id', isEntityValid([{ model: Offer, idName: 'id' }]), asyncWrapper(offerController.getOfferById))
+router.patch('/:id', isEntityValid([{ model: Offer, idName: 'id' }]), asyncWrapper(offerController.updateOffer))
+router.delete('/:id', isEntityValid([{ model: Offer, idName: 'id' }]), asyncWrapper(offerController.deleteOffer))
 
 module.exports = router

--- a/routes/review.js
+++ b/routes/review.js
@@ -3,8 +3,11 @@ const express = require('express')
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
 const { authMiddleware } = require('~/middlewares/auth')
-const reviewController = require('~/controllers/review')
 const setCurrentUserIdAndRole = require('~/middlewares/setCurrentUserIdAndRole')
+const isEntityValid = require('~/middlewares/entityValidation')
+
+const reviewController = require('~/controllers/review')
+const Review = require('~/models/review')
 
 const router = express.Router({ mergeParams: true })
 
@@ -14,8 +17,8 @@ router.param('id', idValidation)
 
 router.get('/', asyncWrapper(reviewController.getReviews))
 router.post('/', setCurrentUserIdAndRole, asyncWrapper(reviewController.addReview))
-router.get('/:id', asyncWrapper(reviewController.getReviewById))
-router.patch('/:id', asyncWrapper(reviewController.updateReview))
-router.delete('/:id', asyncWrapper(reviewController.deleteReview))
+router.get('/:id', isEntityValid([{ model: Review, idName: 'id' }]), asyncWrapper(reviewController.getReviewById))
+router.patch('/:id', isEntityValid([{ model: Review, idName: 'id' }]), asyncWrapper(reviewController.updateReview))
+router.delete('/:id', isEntityValid([{ model: Review, idName: 'id' }]), asyncWrapper(reviewController.deleteReview))
 
 module.exports = router

--- a/routes/subject.js
+++ b/routes/subject.js
@@ -2,8 +2,11 @@ const express = require('express')
 
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
-const subjectController = require('~/controllers/subject')
 const { authMiddleware } = require('~/middlewares/auth')
+const isEntityValid = require('~/middlewares/entityValidation')
+
+const subjectController = require('~/controllers/subject')
+const Subject = require('~/models/subject')
 
 const router = express.Router({ mergeParams: true })
 
@@ -15,8 +18,8 @@ router.get('/names', asyncWrapper(subjectController.getNamesByCategoryId))
 
 router.get('/', asyncWrapper(subjectController.getSubjects))
 router.post('/', asyncWrapper(subjectController.addSubject))
-router.get('/:id', asyncWrapper(subjectController.getSubjectById))
-router.patch('/:id', asyncWrapper(subjectController.updateSubject))
-router.delete('/:id', asyncWrapper(subjectController.deleteSubject))
+router.get('/:id', isEntityValid([{ model: Subject, idName: 'id' }]), asyncWrapper(subjectController.getSubjectById))
+router.patch('/:id', isEntityValid([{ model: Subject, idName: 'id' }]), asyncWrapper(subjectController.updateSubject))
+router.delete('/:id', isEntityValid([{ model: Subject, idName: 'id' }]), asyncWrapper(subjectController.deleteSubject))
 
 module.exports = router

--- a/routes/user.js
+++ b/routes/user.js
@@ -22,12 +22,12 @@ router.param('id', idValidation)
 router.use('/:id/reviews', isEntityValid([{ model: User, idName: 'id' }]), reviewRouter)
 
 router.get('/', asyncWrapper(userController.getUsers))
-router.get('/:id', asyncWrapper(userController.getOneUser))
+router.get('/:id', isEntityValid([{ model: User, idName: 'id' }]), asyncWrapper(userController.getOneUser))
 router.get('/my-profile', setCurrentUserIdAndRole, asyncWrapper(userController.getOneUser))
 
 router.use(restrictTo(ADMIN))
 
-router.patch('/:id', asyncWrapper(userController.updateUser))
-router.delete('/:id', asyncWrapper(userController.deleteUser))
+router.patch('/:id', isEntityValid([{ model: User, idName: 'id' }]), asyncWrapper(userController.updateUser))
+router.delete('/:id', isEntityValid([{ model: User, idName: 'id' }]), asyncWrapper(userController.deleteUser))
 
 module.exports = router

--- a/routes/user.js
+++ b/routes/user.js
@@ -5,13 +5,13 @@ const asyncWrapper = require('~/middlewares/asyncWrapper')
 const setCurrentUserIdAndRole = require('~/middlewares/setCurrentUserIdAndRole')
 const { restrictTo, authMiddleware } = require('~/middlewares/auth')
 const isEntityValid = require('~/middlewares/entityValidation')
-const {
-  roles: { ADMIN }
-} = require('~/consts/auth')
 
 const User = require('~/models/user')
 const userController = require('~/controllers/user')
 const reviewRouter = require('~/routes/review')
+const {
+  roles: { ADMIN }
+} = require('~/consts/auth')
 
 const router = express.Router()
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -4,8 +4,12 @@ const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
 const setCurrentUserIdAndRole = require('~/middlewares/setCurrentUserIdAndRole')
 const { restrictTo, authMiddleware } = require('~/middlewares/auth')
-const { roles: { ADMIN } } = require('~/consts/auth')
+const isEntityValid = require('~/middlewares/entityValidation')
+const {
+  roles: { ADMIN }
+} = require('~/consts/auth')
 
+const User = require('~/models/user')
 const userController = require('~/controllers/user')
 const reviewRouter = require('~/routes/review')
 
@@ -15,7 +19,7 @@ router.use(authMiddleware)
 
 router.param('id', idValidation)
 
-router.use('/:id/reviews', reviewRouter)
+router.use('/:id/reviews', isEntityValid([{ model: User, idName: 'id' }]), reviewRouter)
 
 router.get('/', asyncWrapper(userController.getUsers))
 router.get('/:id', asyncWrapper(userController.getOneUser))

--- a/services/auth.js
+++ b/services/auth.js
@@ -9,7 +9,6 @@ const {
   EMAIL_NOT_CONFIRMED,
   BAD_CONFIRM_TOKEN,
   INCORRECT_CREDENTIALS,
-  EMAIL_NOT_FOUND,
   BAD_RESET_TOKEN,
   BAD_REFRESH_TOKEN,
   USER_NOT_FOUND
@@ -135,7 +134,7 @@ const authService = {
     const user = await getUserByEmail(email)
 
     if (!user) {
-      throw createError(404, EMAIL_NOT_FOUND)
+      throw createError(404, USER_NOT_FOUND)
     }
 
     const { _id, firstName } = user

--- a/services/category.js
+++ b/services/category.js
@@ -1,6 +1,4 @@
 const Category = require('~/models/category')
-const { createError } = require('~/utils/errorsHelper')
-const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 
 const categoryService = {
   getCategories: async (searchFilter, skip, limit) => {
@@ -13,10 +11,6 @@ const categoryService = {
 
   getCategoryById: async (id) => {
     const category = await Category.findById(id).lean().exec()
-
-    if (!category) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Category.modelName))
-    }
 
     return category
   }

--- a/services/category.js
+++ b/services/category.js
@@ -1,6 +1,6 @@
 const Category = require('~/models/category')
 const { createError } = require('~/utils/errorsHelper')
-const { CATEGORY_NOT_FOUND } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 
 const categoryService = {
   getCategories: async (searchFilter, skip, limit) => {
@@ -15,7 +15,7 @@ const categoryService = {
     const category = await Category.findById(id).lean().exec()
 
     if (!category) {
-      throw createError(404, CATEGORY_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Category.modelName))
     }
 
     return category

--- a/services/cooperation.js
+++ b/services/cooperation.js
@@ -1,6 +1,4 @@
 const Cooperation = require('~/models/cooperation')
-const { createError } = require('~/utils/errorsHelper')
-const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 
 const cooperationService = {
   getCooperations: async () => {
@@ -11,10 +9,6 @@ const cooperationService = {
 
   getCooperationById: async (id) => {
     const cooperation = await Cooperation.findById(id).lean().exec()
-
-    if (!cooperation) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Cooperation.modelName))
-    }
 
     return cooperation
   },
@@ -36,11 +30,8 @@ const cooperationService = {
       ...(price && { price }),
       ...(status && { status })
     }
-    const cooperation = await Cooperation.findByIdAndUpdate(id, filteredData, { new: true }).lean().exec()
 
-    if (!cooperation) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Cooperation.modelName))
-    }
+    await Cooperation.findByIdAndUpdate(id, filteredData, { new: true }).lean().exec()
   }
 }
 

--- a/services/cooperation.js
+++ b/services/cooperation.js
@@ -1,6 +1,6 @@
 const Cooperation = require('~/models/cooperation')
 const { createError } = require('~/utils/errorsHelper')
-const { COOPERATION_NOT_FOUND } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 
 const cooperationService = {
   getCooperations: async () => {
@@ -13,7 +13,7 @@ const cooperationService = {
     const cooperation = await Cooperation.findById(id).lean().exec()
 
     if (!cooperation) {
-      throw createError(404, COOPERATION_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Cooperation.modelName))
     }
 
     return cooperation
@@ -39,7 +39,7 @@ const cooperationService = {
     const cooperation = await Cooperation.findByIdAndUpdate(id, filteredData, { new: true }).lean().exec()
 
     if (!cooperation) {
-      throw createError(404, COOPERATION_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Cooperation.modelName))
     }
   }
 }

--- a/services/offer.js
+++ b/services/offer.js
@@ -1,10 +1,10 @@
 const Offer = require('~/models/offer')
 const { createError } = require('~/utils/errorsHelper')
-const { OFFER_NOT_FOUND } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 
 const offerService = {
-  getOffers: async (filters) => {
-    const offers = await Offer.find(filters).lean().exec()
+  getOffers: async (match) => {
+    const offers = await Offer.find(match).lean().exec()
 
     return offers
   },
@@ -13,7 +13,7 @@ const offerService = {
     const offer = await Offer.findById(id).lean().exec()
 
     if (!offer) {
-      throw createError(404, OFFER_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Offer.modelName))
     }
 
     return offer
@@ -42,7 +42,7 @@ const offerService = {
     const offer = await Offer.findByIdAndUpdate(id, updateData).lean().exec()
 
     if (!offer) {
-      throw createError(404, OFFER_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Offer.modelName))
     }
   },
 
@@ -50,7 +50,7 @@ const offerService = {
     const offer = await Offer.findByIdAndRemove(id).exec()
 
     if (!offer) {
-      throw createError(404, OFFER_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Offer.modelName))
     }
   }
 }

--- a/services/offer.js
+++ b/services/offer.js
@@ -1,6 +1,4 @@
 const Offer = require('~/models/offer')
-const { createError } = require('~/utils/errorsHelper')
-const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 
 const offerService = {
   getOffers: async (match) => {
@@ -11,10 +9,6 @@ const offerService = {
 
   getOfferById: async (id) => {
     const offer = await Offer.findById(id).lean().exec()
-
-    if (!offer) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Offer.modelName))
-    }
 
     return offer
   },
@@ -39,19 +33,11 @@ const offerService = {
   },
 
   updateOffer: async (id, updateData) => {
-    const offer = await Offer.findByIdAndUpdate(id, updateData).lean().exec()
-
-    if (!offer) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Offer.modelName))
-    }
+    await Offer.findByIdAndUpdate(id, updateData).lean().exec()
   },
 
   deleteOffer: async (id) => {
-    const offer = await Offer.findByIdAndRemove(id).exec()
-
-    if (!offer) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Offer.modelName))
-    }
+    await Offer.findByIdAndRemove(id).exec()
   }
 }
 

--- a/services/offer.js
+++ b/services/offer.js
@@ -3,8 +3,8 @@ const { createError } = require('~/utils/errorsHelper')
 const { OFFER_NOT_FOUND } = require('~/consts/errors')
 
 const offerService = {
-  getOffers: async () => {
-    const offers = await Offer.find().lean().exec()
+  getOffers: async (filters) => {
+    const offers = await Offer.find(filters).lean().exec()
 
     return offers
   },

--- a/services/review.js
+++ b/services/review.js
@@ -1,6 +1,6 @@
 const Review = require('~/models/review')
 const { createError } = require('~/utils/errorsHelper')
-const { REVIEW_NOT_FOUND } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 
 const reviewService = {
   getReviews: async (match, skip, limit) => {
@@ -42,7 +42,7 @@ const reviewService = {
       .exec()
 
     if (!review) {
-      throw createError(404, REVIEW_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Review.modelName))
     }
 
     return review
@@ -65,7 +65,7 @@ const reviewService = {
     const review = await Review.findByIdAndUpdate(id, updateData).lean().exec()
 
     if (!review) {
-      throw createError(404, REVIEW_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Review.modelName))
     }
   },
 
@@ -73,7 +73,7 @@ const reviewService = {
     const review = await Review.findByIdAndRemove(id).exec()
 
     if (!review) {
-      throw createError(404, REVIEW_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Review.modelName))
     }
   }
 }

--- a/services/review.js
+++ b/services/review.js
@@ -1,6 +1,4 @@
 const Review = require('~/models/review')
-const { createError } = require('~/utils/errorsHelper')
-const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 
 const reviewService = {
   getReviews: async (match, skip, limit) => {
@@ -41,10 +39,6 @@ const reviewService = {
       .lean()
       .exec()
 
-    if (!review) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Review.modelName))
-    }
-
     return review
   },
 
@@ -62,19 +56,11 @@ const reviewService = {
   },
 
   updateReview: async (id, updateData) => {
-    const review = await Review.findByIdAndUpdate(id, updateData).lean().exec()
-
-    if (!review) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Review.modelName))
-    }
+    await Review.findByIdAndUpdate(id, updateData).lean().exec()
   },
 
   deleteReview: async (id) => {
-    const review = await Review.findByIdAndRemove(id).exec()
-
-    if (!review) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Review.modelName))
-    }
+    await Review.findByIdAndRemove(id).exec()
   }
 }
 

--- a/services/subject.js
+++ b/services/subject.js
@@ -1,6 +1,6 @@
 const Subject = require('~/models/subject')
 const { createError } = require('~/utils/errorsHelper')
-const { DOCUMENT_NOT_FOUND, SUBJECT_ALREADY_EXISTS } = require('~/consts/errors')
+const { SUBJECT_ALREADY_EXISTS } = require('~/consts/errors')
 
 const subjectService = {
   getSubjects: async ({ skip, limit, searchFilter }) => {
@@ -11,10 +11,6 @@ const subjectService = {
 
   getSubjectById: async (id) => {
     const subject = await Subject.findById(id).lean().exec()
-
-    if (!subject) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Subject.modelName))
-    }
 
     return subject
   },
@@ -35,19 +31,11 @@ const subjectService = {
   },
 
   updateSubject: async (id, updateData) => {
-    const subject = await Subject.findByIdAndUpdate(id, updateData).lean().exec()
-
-    if (!subject) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Subject.modelName))
-    }
+    await Subject.findByIdAndUpdate(id, updateData).lean().exec()
   },
 
   deleteSubject: async (id) => {
-    const subject = await Subject.findByIdAndRemove(id).exec()
-
-    if (!subject) {
-      throw createError(404, DOCUMENT_NOT_FOUND(Subject.modelName))
-    }
+    await Subject.findByIdAndRemove(id).exec()
   }
 }
 

--- a/services/subject.js
+++ b/services/subject.js
@@ -1,6 +1,6 @@
 const Subject = require('~/models/subject')
 const { createError } = require('~/utils/errorsHelper')
-const { SUBJECT_NOT_FOUND, SUBJECT_ALREADY_EXISTS } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND, SUBJECT_ALREADY_EXISTS } = require('~/consts/errors')
 
 const subjectService = {
   getSubjects: async ({ skip, limit, searchFilter }) => {
@@ -13,7 +13,7 @@ const subjectService = {
     const subject = await Subject.findById(id).lean().exec()
 
     if (!subject) {
-      throw createError(404, SUBJECT_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Subject.modelName))
     }
 
     return subject
@@ -38,7 +38,7 @@ const subjectService = {
     const subject = await Subject.findByIdAndUpdate(id, updateData).lean().exec()
 
     if (!subject) {
-      throw createError(404, SUBJECT_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Subject.modelName))
     }
   },
 
@@ -46,7 +46,7 @@ const subjectService = {
     const subject = await Subject.findByIdAndRemove(id).exec()
 
     if (!subject) {
-      throw createError(404, SUBJECT_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(Subject.modelName))
     }
   }
 }

--- a/services/user.js
+++ b/services/user.js
@@ -3,7 +3,7 @@ const calculateReviewStats = require('~/utils/reviews/reviewStatsAggregation')
 const { hashPassword } = require('~/utils/passwordHelper')
 const { createError } = require('~/utils/errorsHelper')
 
-const { USER_NOT_FOUND, ALREADY_REGISTERED } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND, ALREADY_REGISTERED } = require('~/consts/errors')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -31,7 +31,7 @@ const userService = {
       .exec()
 
     if (!user) {
-      throw createError(404, USER_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(User.modelName))
     }
 
     const reviewStats = await calculateReviewStats(user._id, role)
@@ -43,7 +43,7 @@ const userService = {
     const user = await User.findById(id).select('+lastLoginAs +isEmailConfirmed +isFirstLogin').lean().exec()
 
     if (!user) {
-      throw createError(404, USER_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(User.modelName))
     }
 
     return user
@@ -89,19 +89,19 @@ const userService = {
     const user = await User.findByIdAndUpdate(id, param, { new: true }).exec()
 
     if (!user) {
-      throw createError(404, USER_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(User.modelName))
     }
   },
 
   updateUser: async (id, updateStatus) => {
-    const statusesForChange = {} 
+    const statusesForChange = {}
     for (const role in updateStatus) {
       statusesForChange['status.' + role] = updateStatus[role]
     }
 
-    const user = await User.findByIdAndUpdate(id, { $set:statusesForChange }, { new: true }).exec()
+    const user = await User.findByIdAndUpdate(id, { $set: statusesForChange }, { new: true }).exec()
     if (!user) {
-      throw createError(404, USER_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(User.modelName))
     }
   },
 
@@ -109,7 +109,7 @@ const userService = {
     const user = await User.findByIdAndRemove(id).exec()
 
     if (!user) {
-      throw createError(404, USER_NOT_FOUND)
+      throw createError(404, DOCUMENT_NOT_FOUND(User.modelName))
     }
   }
 }

--- a/services/user.js
+++ b/services/user.js
@@ -30,10 +30,6 @@ const userService = {
       .lean()
       .exec()
 
-    if (!user) {
-      throw createError(404, DOCUMENT_NOT_FOUND(User.modelName))
-    }
-
     const reviewStats = await calculateReviewStats(user._id, role)
 
     return { ...user, reviewStats }
@@ -99,18 +95,11 @@ const userService = {
       statusesForChange['status.' + role] = updateStatus[role]
     }
 
-    const user = await User.findByIdAndUpdate(id, { $set: statusesForChange }, { new: true }).exec()
-    if (!user) {
-      throw createError(404, DOCUMENT_NOT_FOUND(User.modelName))
-    }
+    await User.findByIdAndUpdate(id, { $set: statusesForChange }, { new: true }).exec()
   },
 
   deleteUser: async (id) => {
-    const user = await User.findByIdAndRemove(id).exec()
-
-    if (!user) {
-      throw createError(404, DOCUMENT_NOT_FOUND(User.modelName))
-    }
+    await User.findByIdAndRemove(id).exec()
   }
 }
 

--- a/test/integration/controllers/auth.spec.js
+++ b/test/integration/controllers/auth.spec.js
@@ -217,10 +217,10 @@ describe('Auth controller', () => {
 
       expect(response.statusCode).toBe(204)
     })
-    it('should throw EMAIL_NOT_FOUND error', async () => {
+    it('should throw USER_NOT_FOUND error', async () => {
       const response = await app.post('/auth/forgot-password').send({ email: 'invalid@gmail.com' })
 
-      expectError(404, errors.EMAIL_NOT_FOUND, response)
+      expectError(404, errors.USER_NOT_FOUND, response)
     })
   })
 

--- a/test/integration/controllers/category.spec.js
+++ b/test/integration/controllers/category.spec.js
@@ -1,7 +1,7 @@
 const { serverInit, serverCleanup } = require('~/test/setup')
 const testUserAuthentication = require('~/utils/testUserAuth')
 const { expectError } = require('~/test/helpers')
-const { CATEGORY_NOT_FOUND, UNAUTHORIZED } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND, UNAUTHORIZED } = require('~/consts/errors')
 const Category = require('~/models/category')
 
 const endpointUrl = '/categories/'
@@ -94,10 +94,10 @@ describe('Category controller', () => {
       expectError(401, UNAUTHORIZED, response)
     })
 
-    it('should throw CATEGORY_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app.get(endpointUrl + nonExistingReviewId).set('Authorization', `Bearer ${accessToken}`)
 
-      expectError(404, CATEGORY_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Category.modelName), response)
     })
 
     it('should get a category by id', async () => {

--- a/test/integration/controllers/offer.spec.js
+++ b/test/integration/controllers/offer.spec.js
@@ -1,7 +1,8 @@
 const { serverCleanup, serverInit } = require('~/test/setup')
 const { expectError } = require('~/test/helpers')
-const { OFFER_NOT_FOUND } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 const testUserAuthentication = require('~/utils/testUserAuth')
+const Offer = require('~/models/offer')
 
 const endpointUrl = '/offers/'
 const nonExistingOfferId = '6329a45601bd35b5fff1cf8c'
@@ -76,10 +77,10 @@ describe('Offer controller', () => {
       expect(response.statusCode).toBe(200)
     })
 
-    it('should throw OFFER_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app.get(endpointUrl + nonExistingOfferId).set('Authorization', `Bearer ${accessToken}`)
 
-      expectError(404, OFFER_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Offer.modelName), response)
     })
   })
 
@@ -93,13 +94,13 @@ describe('Offer controller', () => {
       expect(response.statusCode).toBe(204)
     })
 
-    it('should throw OFFER_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app
         .patch(endpointUrl + nonExistingOfferId)
         .set('Authorization', `Bearer ${accessToken}`)
         .send(updateData)
 
-      expectError(404, OFFER_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Offer.modelName), response)
     })
   })
 
@@ -110,10 +111,10 @@ describe('Offer controller', () => {
       expect(response.statusCode).toBe(204)
     })
 
-    it('should throw OFFER_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app.get(endpointUrl + nonExistingOfferId).set('Authorization', `Bearer ${accessToken}`)
 
-      expectError(404, OFFER_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Offer.modelName), response)
     })
   })
 })

--- a/test/integration/controllers/review.spec.js
+++ b/test/integration/controllers/review.spec.js
@@ -1,7 +1,8 @@
 const { serverInit, serverCleanup } = require('~/test/setup')
-const { REVIEW_NOT_FOUND, UNAUTHORIZED } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND, UNAUTHORIZED } = require('~/consts/errors')
 const { expectError } = require('~/test/helpers')
 const testUserAuthentication = require('~/utils/testUserAuth')
+const Review = require('~/models/review')
 
 const endpointUrl = '/reviews/'
 
@@ -81,10 +82,10 @@ describe('Review controller', () => {
       expect(response.body).toEqual(expect.objectContaining(testReview))
     })
 
-    it('should throw REVIEW_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app.get(endpointUrl + nonExistingReviewId).set('Authorization', `Bearer ${accessToken}`)
 
-      expectError(404, REVIEW_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Review.modelName), response)
     })
   })
 
@@ -104,13 +105,13 @@ describe('Review controller', () => {
       expect(response.statusCode).toBe(204)
     })
 
-    it('should throw REVIEW_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app
         .patch(endpointUrl + nonExistingReviewId)
         .set('Authorization', `Bearer ${accessToken}`)
         .send(updateData)
 
-      expectError(404, REVIEW_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Review.modelName), response)
     })
   })
 
@@ -127,10 +128,10 @@ describe('Review controller', () => {
       expect(response.statusCode).toBe(204)
     })
 
-    it('should throw REVIEW_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app.delete(endpointUrl + nonExistingReviewId).set('Authorization', `Bearer ${accessToken}`)
 
-      expectError(404, REVIEW_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Review.modelName), response)
     })
   })
 })

--- a/test/integration/controllers/subject.spec.js
+++ b/test/integration/controllers/subject.spec.js
@@ -1,7 +1,8 @@
 const { serverCleanup, serverInit } = require('~/test/setup')
 const { expectError } = require('~/test/helpers')
-const { SUBJECT_NOT_FOUND, SUBJECT_ALREADY_EXISTS } = require('~/consts/errors')
+const { DOCUMENT_NOT_FOUND, SUBJECT_ALREADY_EXISTS } = require('~/consts/errors')
 const testUserAuthentication = require('~/utils/testUserAuth')
+const Subject = require('~/models/subject')
 
 const endpointUrl = '/subjects/'
 const nonExistingSubjectId = '63cf23e07281224fbbee5958'
@@ -81,10 +82,10 @@ describe('Subject controller', () => {
       )
     })
 
-    it('should throw SUBJECT_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app.get(endpointUrl + nonExistingSubjectId).set('Authorization', `Bearer ${accessToken}`)
 
-      expectError(404, SUBJECT_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Subject.modelName), response)
     })
   })
 
@@ -98,13 +99,13 @@ describe('Subject controller', () => {
       expect(response.statusCode).toBe(204)
     })
 
-    it('should throw SUBJECT_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app
         .patch(endpointUrl + nonExistingSubjectId)
         .set('Authorization', `Bearer ${accessToken}`)
         .send({ name: 'Eng' })
 
-      expectError(404, SUBJECT_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Subject.modelName), response)
     })
   })
 
@@ -117,12 +118,12 @@ describe('Subject controller', () => {
       expect(response.statusCode).toBe(204)
     })
 
-    it('should throw SUBJECT_NOT_FOUND', async () => {
+    it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app
         .delete(endpointUrl + nonExistingSubjectId)
         .set('Authorization', `Bearer ${accessToken}`)
 
-      expectError(404, SUBJECT_NOT_FOUND, response)
+      expectError(404, DOCUMENT_NOT_FOUND(Subject.modelName), response)
     })
   })
 })


### PR DESCRIPTION
1) added a route for offers with optional params for categoryId and subjectId

categories/:categoryId?/subjects/subjectId?/offers

if you pass both `categoryId` and `subjectId`, you will get all offers that belong to the specified category and subject
if you pass `categoryId`, you will get all offers that belong to the specified category
if you pass `subjectId`, you will get all offers that belong to the specified subject
if you pass no params, you will get all offers

2) made a generic error message for NOT_FOUND entities & replaced it everywhere & swagger
removed useless error messages

3) added a middleware that checks whether entity exists or not
4) applied it to each nested enpoint
5) modified param validation

