### PR TITLE
Changed sorting in "Get lessons" endpoint

### DIFF
--- a/controllers/lesson.js
+++ b/controllers/lesson.js
@@ -1,5 +1,7 @@
 const lessonService = require('~/services/lesson')
 const getMatchOptions = require('~/utils/getMatchOptions')
+const getRegex = require('~/utils/getRegex')
+const getSortOptions = require('~/utils/getSortOptions')
 
 const createLesson = async (req, res) => {
   const { id: author } = req.user
@@ -22,9 +24,10 @@ const getLessons = async (req, res) => {
   const { id: author } = req.user
   const { title, sort, skip, limit } = req.query
 
-  const match = getMatchOptions({ author, title })
+  const match = getMatchOptions({ author, title: getRegex(title) })
+  const sortOptions = getSortOptions(sort)
 
-  const lessons = await lessonService.getLessons(match, sort, parseInt(skip), parseInt(limit))
+  const lessons = await lessonService.getLessons(match, sortOptions, parseInt(skip), parseInt(limit))
 
   res.status(200).json(lessons)
 }

--- a/utils/getSortOptions.js
+++ b/utils/getSortOptions.js
@@ -1,0 +1,10 @@
+const getSortOptions = (sort) => {
+  try {
+    const { order, orderBy } = JSON.parse(sort)
+    return { [orderBy || 'updatedAt']: order || 'asc' }
+  } catch (error) {
+    return { updatedAt: 'asc' }
+  }
+}
+
+module.exports = getSortOptions


### PR DESCRIPTION
Changed sorting in "Get lessons" endpoint for the client needs and sort functionality
Passed tests of lessons:
<img width="580" alt="image" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/90138904/07722c95-69fd-461d-bbcd-38dfe007dd45">