### PR TITLE
Supplemented db with banner field for course // Not relevant

### DIFF
--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -6,6 +6,8 @@ definitions:
       properties:
         _id:
           type: string
+        banner:
+          type: string
         title:
           type: string
         description:
@@ -34,6 +36,8 @@ definitions:
     properties:
       _id:
         type: string
+      banner:
+        type: string
       title:
         type: string
       description:
@@ -60,6 +64,8 @@ definitions:
   courseBody:
     type: object
     properties:
+      banner:
+        type: string
       title:
         type: string
       description:

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -28,7 +28,8 @@ paths:
               schema:
                 $ref: '#/definitions/course'
               example:
-                - _id: 64045f98b131dd04d7896af6
+                - _id: 64045f98b131dd04d7896af6,
+                  banner: 247829-banner.jpg
                   title: Advanced English
                   description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
                   author: 63da8767c9ad4c9a0b0eacd3
@@ -80,6 +81,7 @@ paths:
             schema:
               $ref: '#definitions/courseBody'
             example:
+              banner: 247829-banner.jpg
               title: Advanced English
               description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
               author: 63da8767c9ad4c9a0b0eacd3
@@ -93,6 +95,7 @@ paths:
               schema:
                 $ref: '#definitions/course'
               example:
+                banner: 247829-banner.jpg
                 title: Advanced English
                 description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
                 author: 63da8767c9ad4c9a0b0eacd3
@@ -206,6 +209,7 @@ paths:
               schema:
                 $ref: '#definitions/course'
               example:
+                banner: 247829-banner.jpg
                 title: Advanced English
                 description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
                 author: 63da8767c9ad4c9a0b0eacd3

--- a/models/course.js
+++ b/models/course.js
@@ -5,6 +5,9 @@ const { COURSE, USER, LESSON, ATTACHMENT } = require('~/consts/models')
 
 const courseSchema = new Schema(
   {
+    banner: {
+      type: String
+    },
     title: {
       type: String,
       required: [true, FIELD_CANNOT_BE_EMPTY('title')],

--- a/services/course.js
+++ b/services/course.js
@@ -16,9 +16,10 @@ const courseService = {
   },
 
   createCourse: async (author, data) => {
-    const { title, description, lessons, attachments } = data
+    const { banner, title, description, lessons, attachments } = data
 
     return await Course.create({
+      banner,
       title,
       description,
       author,
@@ -28,7 +29,7 @@ const courseService = {
   },
 
   updateCourse: async (userId, data) => {
-    const { id, title, description, attachments, rewriteAttachments = false } = data
+    const { id, banner, title, description, attachments, rewriteAttachments = false } = data
 
     const course = await Course.findById(id).exec()
 
@@ -46,7 +47,7 @@ const courseService = {
       course.attachments = rewriteAttachments ? attachments : course.attachments.concat(attachments)
     }
 
-    const updateData = { title, description }
+    const updateData = { banner, title, description }
 
     for (const key in updateData) {
       const value = updateData[key]

--- a/test/integration/controllers/course.spec.js
+++ b/test/integration/controllers/course.spec.js
@@ -26,6 +26,7 @@ let tutorUser = {
 }
 
 const testCourseData = {
+  banner: 'img-path',
   title: 'assembly',
   description: 'you will learn some modern programming language for all your needs',
   attachments: [
@@ -94,6 +95,7 @@ describe('Course controller', () => {
     it('should create a course', async () => {
       expect(testCourseResponse.statusCode).toBe(201)
       expect(testCourseResponse.body).toMatchObject({
+        banner: testCourseData.banner,
         title: testCourseData.title,
         description: testCourseData.description,
         attachments: ['mocked-file-url'],
@@ -161,6 +163,7 @@ describe('Course controller', () => {
       expect(response.statusCode).toBe(200)
       expect(response.body).toMatchObject({
         _id: expect.any(String),
+        banner: expect.any(String),
         author: expect.any(String),
         title: 'assembly',
         description: 'you will learn some modern programming language for all your needs',


### PR DESCRIPTION
Changes for supplementing database with `banner` field for course has been made (models, etc)

<img width="850" alt="Postman" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/108689551/c4983dae-7159-42c5-88d7-a9b68a806574">

Closes #615 