### PR TITLE
Fixed wrong deletion logic from the DB

### DIFF
--- a/services/message.js
+++ b/services/message.js
@@ -85,7 +85,7 @@ const messageService = {
 
     if (!existingChat) throw createForbiddenError()
 
-    const deleteResult = await Message.deleteMany({ chat, 'clearedFor.user': { $exists: true } }).exec()
+    const deleteResult = await Message.deleteMany({ chat, 'clearedFor.user': { $exists: true, $ne: user } }).exec()
 
     const updateResult = await Message.updateMany(
       { chat, 'clearedFor.user': { $exists: false } },


### PR DESCRIPTION
user_1, user_2
```
{
  "_id": {
    "$oid": "65568c34d556695822907892"
  },
  "text": "Hi!",
  "clearedFor": [user_1],
}
```

**Previously:**
**user_1** could delete the message entirely from DB even if he is in `clearedFor` field (**user_2** could do this too)

**Now:**
Only **user_2** can delete the message entirely from DB (we need to have **user_1** in `clearedFor` field for this)