### PR TITLE
Added 400 status code for patch users id

### DIFF
--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -345,6 +345,16 @@ paths:
       responses:
         204:
           description: No Content
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/Error'
+              example:
+                status: 400
+                code: 'INVALID_ID'
+                message: 'ID is invalid.'
         401:
           description: Unauthorized
           content:
@@ -597,7 +607,7 @@ paths:
   /users/{id}/cooperations:
     get:
       security:
-        - cookieAuth: [ ]
+        - cookieAuth: []
       tags:
         - Users
       summary: Find cooperations for a user with the specified ID


### PR DESCRIPTION
Was added status code 400 (Bad Request) for `/users/{id}` PATCH method

<img width="747" alt="image" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/56305508/7c638415-f245-4fee-82d2-96d1ba7069c7">

**Fixed:** #650 