### PR TITLE
Changed swagger for Users and Comments

### DIFF
--- a/docs/comment/comment.yaml
+++ b/docs/comment/comment.yaml
@@ -71,6 +71,12 @@ paths:
       description: Creates and saves a new comment for specific cooperation.
       produces:
         - application/json
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the cooperation is required, to which the comment will be added
+          type: string
       requestBody:
         required: true
         description: Create new comment.

--- a/docs/review/review-schema.yaml
+++ b/docs/review/review-schema.yaml
@@ -84,3 +84,15 @@ definitions:
         type: string
       rating:
         type: number
+  reviewStats:
+    type: object
+    properties:
+      stats:
+        type: array
+        items:
+          type: object
+          properties:
+            rating:
+              type: integer
+            count:
+              type: integer

--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -561,13 +561,18 @@ paths:
           required: true
           description: ID of the user for which we are looking for review statistics
           type: string
+        - in: query
+          name: role
+          required: true
+          schema:
+            type: string
       responses:
         200:
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/definitions/userStatsResponse'
+                $ref: '#/definitions/reviewStats'
               example:
                 stats: [{ rating: 5, count: 1 }, { rating: 3, count: 1 }]
         400:
@@ -616,6 +621,29 @@ paths:
           required: true
           description: ID of the user for whom we trying to find cooperations
           type: string
+        - in: query
+          name: sort
+          schema:
+            type: string
+            default: { "order": "asc", "orderBy":"updatedAt" }
+          required: false
+        - in: query
+          name: skip
+          schema:
+            type: integer
+            default: 0
+        - in: query
+          name: status
+          schema:
+            type: string
+            default: 0
+          required: false
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 5
+          required: false
       responses:
         200:
           description: OK
@@ -681,7 +709,6 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: id
           in: path
           required: true
           description: ID of the user for whom we trying to find offers


### PR DESCRIPTION
Changed swagger documentation for `Users` and `Comments`

## Users

<img width="756" alt="Знімок екрана 2023-12-06 о 16 48 15" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/108689551/bc38483b-7f7c-4d36-9ac6-4b00a3e26163">
<img width="680" alt="Знімок екрана 2023-12-06 о 16 48 33" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/108689551/6fb1acc1-3145-49cd-8cfa-97dfcefb9877">
<img width="665" alt="Знімок екрана 2023-12-06 о 16 48 47" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/108689551/d95b4dc3-b7a9-4243-8cfb-4676d6e77bed">


## Comments

<img width="788" alt="Знімок екрана 2023-12-06 о 16 49 17" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/108689551/436c6478-e79b-4b1b-9ee8-217b18591452">


Closes #646 #647 
