### PR TITLE
Enable students to access lessons

### DIFF
--- a/src/routes/lesson.js
+++ b/src/routes/lesson.js
@@ -18,11 +18,11 @@ router.use(authMiddleware)
 
 router.param('id', idValidation)
 
-router.use(restrictTo(TUTOR))
+router.get('/:id', isEntityValid({ params }), asyncWrapper(lessonController.getLessonById))
 router.get('/', asyncWrapper(lessonController.getLessons))
+router.use(restrictTo(TUTOR))
 router.post('/', isEntityValid({ body }), asyncWrapper(lessonController.createLesson))
 router.patch('/:id', isEntityValid({ params }), asyncWrapper(lessonController.updateLesson))
 router.delete('/:id', isEntityValid({ params }), asyncWrapper(lessonController.deleteLesson))
-router.get('/:id', isEntityValid({ params }), asyncWrapper(lessonController.getLessonById))
 
 module.exports = router

--- a/src/test/integration/controllers/lesson.spec.js
+++ b/src/test/integration/controllers/lesson.spec.js
@@ -49,7 +49,7 @@ describe('Lesson controller', () => {
   let app, server, accessToken, studentAccessToken, testLessonResponse, testLessonId
 
   beforeAll(async () => {
-    ; ({ app, server } = await serverInit())
+    ;({ app, server } = await serverInit())
   })
 
   beforeEach(async () => {
@@ -224,13 +224,6 @@ describe('Lesson controller', () => {
       const response = await app.get(endpointUrl)
 
       expectError(401, UNAUTHORIZED, response)
-    })
-    it('should throw FORBIDDEN', async () => {
-      const response = await app
-        .get(endpointUrl + testLessonResponse.body._id)
-        .set('Cookie', [`accessToken=${studentAccessToken}`])
-
-      expectError(403, FORBIDDEN, response)
     })
   })
 })


### PR DESCRIPTION
Currently, students cannot get lessons, but they should be able to do so in order to learn the lesson on the Cooperation page according to the [frontend issue](https://github.com/ita-social-projects/SpaceToStudy-Client/issues/1822).

To achieve this the placement of `router.use(restrictTo(TUTOR))` was changed.
The test was changed accordingly.