### PR TITLE
Added account deactivation and activation logic

### DIFF
--- a/src/consts/validation.js
+++ b/src/consts/validation.js
@@ -18,7 +18,7 @@ const enums = {
   ROLE_ENUM: ['student', 'tutor', 'admin', 'superadmin'],
   LOGIN_ROLE_ENUM: ['student', 'tutor', 'admin'],
   MAIN_ROLE_ENUM: ['student', 'tutor'],
-  STATUS_ENUM: ['active', 'blocked'],
+  STATUS_ENUM: ['active', 'blocked', 'deactivated'],
   COOPERATION_STATUS_ENUM: ['pending', 'active', 'declined', 'closed'],
   PARAMS_ENUM: ['id', 'categoryId', 'subjectId'],
   OFFER_STATUS_ENUM: ['active', 'draft', 'closed'],

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -57,7 +57,8 @@ const deactivateUser = async (req, res) => {
 
   if (id !== currentUserId) throw createForbiddenError()
 
-  await userService.updateStatus(id, { [role]: STATUS_ENUM[2] })
+  const DEACTIVATED_STATUS = STATUS_ENUM[2]
+  await userService.updateStatus(id, { [role]: DEACTIVATED_STATUS })
 
   res.status(204).end()
 }
@@ -68,7 +69,8 @@ const activateUser = async (req, res) => {
 
   if (id !== currentUserId) throw createForbiddenError()
 
-  await userService.updateStatus(id, { [role]: STATUS_ENUM[0] })
+  const ACTIVE_STATUS = STATUS_ENUM[0]
+  await userService.updateStatus(id, { [role]: ACTIVE_STATUS })
 
   res.status(204).end()
 }

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,6 +1,9 @@
 const userService = require('~/services/user')
 const { createForbiddenError } = require('~/utils/errorsHelper')
 const createAggregateOptions = require('~/utils/users/createAggregateOptions')
+const {
+  enums: { STATUS_ENUM }
+} = require('~/consts/validation')
 
 const getUsers = async (req, res) => {
   const { skip, limit, sort, match } = createAggregateOptions(req.query)
@@ -48,10 +51,34 @@ const deleteUser = async (req, res) => {
   res.status(204).end()
 }
 
+const deactivateUser = async (req, res) => {
+  const { role, id: currentUserId } = req.user
+  const { id } = req.params
+
+  if (id !== currentUserId) throw createForbiddenError()
+
+  await userService.updateStatus(id, { [role]: STATUS_ENUM[2] })
+
+  res.status(204).end()
+}
+
+const activateUser = async (req, res) => {
+  const { role, id: currentUserId } = req.user
+  const { id } = req.params
+
+  if (id !== currentUserId) throw createForbiddenError()
+
+  await userService.updateStatus(id, { [role]: STATUS_ENUM[0] })
+
+  res.status(204).end()
+}
+
 module.exports = {
   getUsers,
   getUserById,
   deleteUser,
   updateUser,
-  updateStatus
+  updateStatus,
+  deactivateUser,
+  activateUser
 }

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -27,6 +27,8 @@ router.use('/:id/offers', isEntityValid({ params }), offerRouter)
 router.get('/', asyncWrapper(userController.getUsers))
 router.get('/:id', isEntityValid({ params }), asyncWrapper(userController.getUserById))
 router.patch('/:id', isEntityValid({ params }), asyncWrapper(userController.updateUser))
+router.patch('/:id/deactivate', isEntityValid({ params }), asyncWrapper(userController.deactivateUser))
+router.patch('/:id/activate', isEntityValid({ params }), asyncWrapper(userController.activateUser))
 
 router.use(restrictTo(ADMIN))
 router.patch('/:id/change-status', isEntityValid({ params }), asyncWrapper(userController.updateStatus))


### PR DESCRIPTION
- Added two endpoints, one to deactivate user and another to activate him. I used the same approach as in `update` endpoint, so endpoint has `id`. I guess it can be used later for admin logic.
- Added a bunch of tests, some of them for deactivation and activation, others for offers fetching.
- Added changes in `offerAggregateOptions.js`, so users will not see offers from deactivated accounts. At the same time, if user requests his own offers like this `users/:id/offers` he will see it, even if he is deactivated. This way offers page won't be broken for deactivated users.

Below is a logic for showing user offers only from active accounts. The first condition checks if the user requests data is the user he want to get data for. If it is, we just skip that logic, so deactivated user can see his offers on `my offers` page.
Because we save some user's data like this `status: { student: "active", tutor: "active", admin: "active" }` and one account in perspective will be able to use multiple roles, we need to make check whether role with which user has created offer is deactivated or not (because user can have deactivated one role but another role can be active). That is easy when we have role inside of query parameters. But if we doesn't, we need to use authorRole from offer document (stored as `authorRole`). This means, we need to check from what role user has created offer and than check if that role is active. I came up with query like this (the query uses loop in code), it works perfectly, but there could be other approaches.

```if (authorId !== userId) {
    if (authorRole) {
      match[`author.status.${authorRole}`] = STATUS_ENUM[0]
    } else {
      match['$expr'] = {
        $switch: {
          branches: [
            { case: { $eq: ['$authorRole', 'student'] }, then: { $eq: ['$author.status.student', 'active'] } },
            { case: { $eq: ['$authorRole', 'tutor'] }, then: { $eq: ['$author.status.tutor', 'active'] } },
            { case: { $eq: ['$authorRole', 'admin'] }, then: { $eq: ['$author.status.admin', 'active'] } }
          ]
        }
      }
    }
  }```