### PR TITLE
Implemented sorting categories by totaloffers

### DIFF
--- a/docs/category/category.yaml
+++ b/docs/category/category.yaml
@@ -25,6 +25,11 @@ paths:
           schema:
             type: string
           required: false
+        - in: query
+          name: sort
+          schema:
+            type: string
+          required: false
       responses:
         200:
           description: OK

--- a/src/test/integration/controllers/categoriesAggregateOptions.spec.js
+++ b/src/test/integration/controllers/categoriesAggregateOptions.spec.js
@@ -1,0 +1,36 @@
+const categoriesAggregateOptions = require('~/utils/categories/categoriesAggregateOptions')
+
+const sortOptionIndex = 3
+
+const checkPropertySortOption = (res, query, sortParam) => {
+  const result = categoriesAggregateOptions(query)
+  expect(result).toBeDefined()
+  expect(result[sortOptionIndex].$sort[sortParam]).toBe(res)
+}
+
+describe('categoriesAggregateOptions', () => {
+  it('should correctly handle search by name', () => {
+    const result = categoriesAggregateOptions({ name: 'testName' })
+    expect(result).toBeDefined()
+  })
+
+  it('should sort by updatedAt in descending order by default', () => {
+    checkPropertySortOption(-1, { sort: undefined }, 'updatedAt')
+  })
+
+  it('should correctly handle sorting (Object) by totalOffers in ascending order', () => {
+    checkPropertySortOption(1, { sort: { order: 'asc', orderBy: 'totalOffersSum' } }, 'totalOffersSum')
+  })
+
+  it('should correctly handle sorting (Object) by totalOffers in descending order', () => {
+    checkPropertySortOption(-1, { sort: { order: 'desc', orderBy: 'totalOffersSum' } }, 'totalOffersSum')
+  })
+
+  it('should correctly handle sorting (String) by totalOffers in ascending order', () => {
+    checkPropertySortOption(1, { sort: 'totalOffersAsc' }, 'totalOffersSum')
+  })
+
+  it('should correctly handle sorting (String) by totalOffers in descending order', () => {
+    checkPropertySortOption(-1, { sort: 'totalOffersDesc' }, 'totalOffersSum')
+  })
+})


### PR DESCRIPTION
## Done

- [x] Implemented sorting categories by totalOffers (totalOffers.student + totalOffers.tutor)
- [x] Added tests for categoriesAggregateOptions
- [x] Updated swagger docs for categories

## Results
- ### Categories are sorted by updatedAt field in descending order by default
![Screenshot 2024-06-24 at 11 34 38](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/74725159/711d5227-6b55-42f1-b82b-78cdb8d2038e)

- ### Categories can be sorted by totalOffers in arc/desc order via sort parameter
![Screenshot 2024-06-24 at 11 34 05](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/74725159/db23cd8b-09d3-4c0d-b601-815027ca321e)

- ### Added tests for categoriesAggregateOptions
![Screenshot 2024-06-24 at 11 51 08](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/74725159/f7a129e2-15ee-46d2-9470-c69cf56160c5)

- ### Updated swagger docs for categories
![Screenshot 2024-06-24 at 11 37 41](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/74725159/65f0c2ce-d36a-48e3-a2dd-850facb8fe32)

