### PR TITLE
Make GetSubjects endpoint return category appearance

### DIFF
--- a/docs/subject/subject-schema.yaml
+++ b/docs/subject/subject-schema.yaml
@@ -9,8 +9,17 @@ definitions:
         name:
           type: string
         category:
-          type: string
-          $ref: '#/components/category'
+          type: object
+          properties:
+            _id:
+              type: string
+            appearance:
+              type: object
+              properties:
+                icon:
+                  type: string
+                color:
+                  type: string
         totalOffers:
           type: object
           properties:

--- a/docs/subject/subject.yaml
+++ b/docs/subject/subject.yaml
@@ -19,13 +19,21 @@ paths:
               example:
                 - _id: 6255bc080a71adf9223df134
                   name: English
-                  category: 63525e23bf163f5ea609ff27
+                  category:
+                    _id: '63525e23bf163f5ea609ff23'
+                    appearance:
+                      color: '#F67C41'
+                      icon: 'mocked-path-to-icon'
                   totalOffers: { student: 10, tutor: 8 }
                   createdAt: 2023-20-01T13:25:36.292Z
                   updatedAt: 2023-20-01T13:25:36.292Z
                 - _id: 6255bc080a71adf9223df135
                   name: Algebra
-                  category: 63525e23bf163f5ea609ff29
+                  category:
+                    _id: '63525e23bf163f5ea609ff23'
+                    appearance:
+                      color: '#F63C43'
+                      icon: 'mocked-path-to-icon'
                   totalOffers: { student: 10, tutor: 8 }
                   createdAt: 2023-20-01T13:25:36.292Z
                   updatedAt: 2023-20-01T13:25:36.292Z

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -6,6 +6,7 @@ const subjectService = {
     const subjects = await Subject.find(searchFilter)
       .skip(skip)
       .limit(limit)
+      .populate({ path: 'category', select: 'appearance' })
       .sort({ totalOffers: -1, updatedAt: -1 })
       .lean()
       .exec()

--- a/src/test/integration/controllers/subject.spec.js
+++ b/src/test/integration/controllers/subject.spec.js
@@ -8,14 +8,14 @@ const checkCategoryExistence = require('~/seed/checkCategoryExistence')
 const endpointUrl = '/subjects/'
 const nonExistingSubjectId = '63cf23e07281224fbbee5958'
 
-const categoryBody = { name: 'testCategory' }
+const categoryBody = { name: 'testCategory', appearance: { color: '#F67C41', icon: 'mocked-path-to-icon' } }
 const subjectBody = { name: 'English' }
 
 describe('Subject controller', () => {
   let app, server, accessToken, testSubject
 
   beforeAll(async () => {
-    ; ({ app, server } = await serverInit())
+    ;({ app, server } = await serverInit())
   })
 
   beforeEach(async () => {
@@ -26,7 +26,7 @@ describe('Subject controller', () => {
       .post('/categories/')
       .set('Cookie', [`accessToken=${accessToken}`])
       .send(categoryBody)
-    const category = categoryResponse.body._id
+    const category = { _id: categoryResponse.body._id, appearance: categoryResponse.body.appearance }
     subjectBody.category = category
 
     testSubject = await app
@@ -59,7 +59,7 @@ describe('Subject controller', () => {
         expect.objectContaining({
           _id: expect.any(String),
           name: subjectBody.name,
-          category: subjectBody.category,
+          category: subjectBody.category._id,
           totalOffers: {
             student: 0,
             tutor: 0
@@ -102,7 +102,7 @@ describe('Subject controller', () => {
         expect.objectContaining({
           _id: expect.any(String),
           name: subjectBody.name,
-          category: subjectBody.category,
+          category: subjectBody.category._id,
           totalOffers: {
             student: 0,
             tutor: 0


### PR DESCRIPTION
Now the GetSubjects response includes category appearance

- [x] updated response body
- [x] updated swagger endpoint docs
- [x] adjusted unit tests

### Response
![image](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/32570823/37fd5f43-91bc-4710-a8c8-15531f89e2b1)
