### PR TITLE
Removed redundant skip and limit options to resolve conflicts

### DIFF
--- a/src/utils/categories/categoriesAggregateOptions.js
+++ b/src/utils/categories/categoriesAggregateOptions.js
@@ -45,12 +45,6 @@ const categoriesAggregateOptions = (query) => {
       $sort: sortOption
     },
     {
-      $skip: parseInt(skip)
-    },
-    {
-      $limit: parseInt(limit)
-    },
-    {
       $project: {
         subjects: 0
       }


### PR DESCRIPTION
- [x] Removed redundant skip and limit from categoriesAggregateOptions to prevent double-skipping and double-limiting of results

![categoryBugFix](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/125293578/05ac319f-b53e-4678-859c-236fff6086ae)
