### PR TITLE
Fixed failing tests on GitHub Actions (CI/Test_DEV) #812

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,9 +27,6 @@ module.exports = {
   coverageReporters: ['html', 'lcov'],
   coverageDirectory: '<rootDir>/src/test/coverage',
   testTimeout: 12000,
-  testMatch: [
-    '<rootDir>/src/test/integration/**/*.spec.js',
-    '<rootDir>/src/test/unit/**/*.spec.js'
-  ],
+  testMatch: ['<rootDir>/src/test/integration/**/*.spec.js', '<rootDir>/src/test/unit/**/*.spec.js'],
   testResultsProcessor: 'jest-sonar-reporter'
 }

--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -167,7 +167,7 @@ describe('Auth controller', () => {
         .split('=')[1]
 
       const decodedRefreshToken = jwt.decode(refreshToken)
-      expect(decodedRefreshToken.exp).toBe(7 * 24 * 60 * 60 + Math.floor(Date.now() / 1000))
+      expect(decodedRefreshToken.exp).toBe(24 * 60 * 60 + Math.floor(Date.now() / 1000))
     })
 
     it('should login a user with [ rememberMe = true ]', async () => {

--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -1,4 +1,11 @@
+const jwt = require('jsonwebtoken')
+const { OAuth2Client } = require('google-auth-library')
+const { expectError } = require('~/test/helpers')
 const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const tokenService = require('~/services/token')
+const authController = require('~/controllers/auth')
+const testUserAuthentication = require('~/utils/testUserAuth')
+const errors = require('~/consts/errors')
 const {
   lengths: { MIN_PASSWORD_LENGTH, MAX_PASSWORD_LENGTH },
   enums: { ROLE_ENUM }
@@ -8,14 +15,6 @@ const {
   oneDayInMs,
   thirtyDaysInMs
 } = require('~/consts/auth')
-const errors = require('~/consts/errors')
-const tokenService = require('~/services/token')
-const Token = require('~/models/token')
-const { expectError } = require('~/test/helpers')
-const { OAuth2Client } = require('google-auth-library')
-const authController = require('~/controllers/auth')
-
-const testUserAuthentication = require('~/utils/testUserAuth')
 
 jest.mock('google-auth-library')
 
@@ -114,10 +113,7 @@ describe('Auth controller', () => {
         user: signupResponse.body.userId
       })
       confirmToken = findConfirmTokenResponse[0].confirmToken
-
-      Token.findOne = jest.fn().mockResolvedValue({ confirmToken })
     })
-    afterEach(() => jest.resetAllMocks())
 
     it('should confirm email', async () => {
       const response = await app.get(`/auth/confirm-email/${confirmToken}`)
@@ -146,42 +142,9 @@ describe('Auth controller', () => {
         user: signupResponse.body.userId
       })
       confirmToken = findConfirmTokenResponse[0].confirmToken
-
-      Token.findOne = jest.fn().mockResolvedValue({ save: jest.fn().mockResolvedValue(confirmToken) })
-    })
-    afterEach(() => jest.resetAllMocks())
-
-    it('should login a user', async () => {
-      await app.get(`/auth/confirm-email/${confirmToken}`)
-
-      const loginUserResponse = await app.post('/auth/login').send({ email: user.email, password: user.password })
-
-      expect(loginUserResponse.statusCode).toBe(200)
-      expect(loginUserResponse.body).toEqual(
-        expect.objectContaining({
-          accessToken: expect.any(String)
-        })
-      )
     })
 
-    it('should login a user with rememberMe = true', async () => {
-      await app.get(`/auth/confirm-email/${confirmToken}`)
-      const loginUserResponse = await app
-        .post('/auth/login')
-        .send({ email: user.email, password: user.password, rememberMe: true })
-
-      expect(loginUserResponse.statusCode).toBe(200)
-      expect(loginUserResponse.body).toEqual(
-        expect.objectContaining({
-          accessToken: expect.any(String)
-        })
-      )
-
-      const cookies = loginUserResponse.header['set-cookie']
-      expect(cookies.some((cookie) => cookie.includes(`Max-Age=${thirtyDaysInMs / 1000}`))).toBe(true)
-    })
-
-    it('should login a user with rememberMe = false', async () => {
+    it('should login a user with [ rememberMe = false ]', async () => {
       await app.get(`/auth/confirm-email/${confirmToken}`)
 
       const loginUserResponse = await app
@@ -197,6 +160,39 @@ describe('Auth controller', () => {
 
       const cookies = loginUserResponse.header['set-cookie']
       expect(cookies.some((cookie) => cookie.includes(`Max-Age=${oneDayInMs / 1000}`))).toBe(true)
+
+      const refreshToken = cookies
+        .find((cookie) => cookie.includes('refreshToken'))
+        .split(';')[0]
+        .split('=')[1]
+
+      const decodedRefreshToken = jwt.decode(refreshToken)
+      expect(decodedRefreshToken.exp).toBe(7 * 24 * 60 * 60 + Math.floor(Date.now() / 1000))
+    })
+
+    it('should login a user with [ rememberMe = true ]', async () => {
+      await app.get(`/auth/confirm-email/${confirmToken}`)
+      const loginUserResponse = await app
+        .post('/auth/login')
+        .send({ email: user.email, password: user.password, rememberMe: true })
+
+      expect(loginUserResponse.statusCode).toBe(200)
+      expect(loginUserResponse.body).toEqual(
+        expect.objectContaining({
+          accessToken: expect.any(String)
+        })
+      )
+
+      const cookies = loginUserResponse.header['set-cookie']
+      expect(cookies.some((cookie) => cookie.includes(`Max-Age=${thirtyDaysInMs / 1000}`))).toBe(true)
+
+      const refreshToken = cookies
+        .find((cookie) => cookie.includes('refreshToken'))
+        .split(';')[0]
+        .split('=')[1]
+
+      const decodedRefreshToken = jwt.decode(refreshToken)
+      expect(decodedRefreshToken.exp).toBe(30 * 24 * 60 * 60 + Math.floor(Date.now() / 1000))
     })
 
     it('should throw INCORRECT_CREDENTIALS error', async () => {
@@ -210,6 +206,7 @@ describe('Auth controller', () => {
 
       expectError(401, errors.INCORRECT_CREDENTIALS, response)
     })
+
     it('should throw EMAIL_NOT_CONFIRMED error', async () => {
       const email = 'test2@gmail.com'
       await app.post('/auth/signup').send({ ...user, email })
@@ -226,10 +223,7 @@ describe('Auth controller', () => {
         user: signupResponse.body.userId
       })
       confirmToken = findConfirmTokenResponse[0].confirmToken
-
-      Token.findOne = jest.fn().mockResolvedValue({ save: jest.fn().mockResolvedValue(confirmToken) })
     })
-    afterEach(() => jest.resetAllMocks())
 
     it('should logout user', async () => {
       await app.get(`/auth/confirm-email/${confirmToken}`)
@@ -251,10 +245,7 @@ describe('Auth controller', () => {
         user: signupResponse.body.userId
       })
       confirmToken = findConfirmTokenResponse[0].confirmToken
-
-      Token.findOne = jest.fn().mockResolvedValue({ save: jest.fn().mockResolvedValue(confirmToken) })
     })
-    afterEach(() => jest.resetAllMocks())
 
     it('should refresh access token', async () => {
       await app.get(`/auth/confirm-email/${confirmToken}`)
@@ -275,6 +266,7 @@ describe('Auth controller', () => {
         })
       )
     })
+
     it('should throw BAD_REFRESH_TOKEN error', async () => {
       const response = await app.get('/auth/refresh').set('Cookie', 'refreshToken=invalid-token')
 
@@ -321,13 +313,13 @@ describe('Auth controller', () => {
 
       await tokenService.saveToken(signupResponse.body.userId, resetToken, RESET_TOKEN)
     })
-    afterEach(() => jest.resetAllMocks())
 
     it('should update a password', async () => {
       const response = await app.patch(`/auth/reset-password/${resetToken}`).send({ password: 'valid_pass1' })
 
       expect(response.statusCode).toBe(204)
     })
+
     it('should throw BAD_RESET_TOKEN error', async () => {
       const response = await app.patch('/auth/reset-password/invalid-token').send({ password: 'valid_pass1' })
 
@@ -348,8 +340,6 @@ describe('Auth controller', () => {
     beforeEach(async () => {
       accessToken = await testUserAuthentication(app)
     })
-
-    afterEach(() => jest.resetAllMocks())
 
     it('should change user password by his ID', async () => {
       const { id: currentUserId } = tokenService.validateAccessToken(accessToken)

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -55,7 +55,6 @@ const sendMail = async (mailOptions) => {
     return result
   } catch (err) {
     logger.error(err)
-    logger.info('MAILER INNER ERROR: ' + JSON.stringify(err))
     throw createError(400, EMAIL_NOT_SENT)
   }
 }

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -55,6 +55,7 @@ const sendMail = async (mailOptions) => {
     return result
   } catch (err) {
     logger.error(err)
+    logger.info('MAILER INNER ERROR: ' + JSON.stringify(err))
     throw createError(400, EMAIL_NOT_SENT)
   }
 }

--- a/src/validation/schemas/login.js
+++ b/src/validation/schemas/login.js
@@ -6,6 +6,10 @@ const loginValidationSchema = {
   password: {
     type: 'string',
     required: true
+  },
+  rememberMe: {
+    type: 'boolean',
+    required: false
   }
 }
 


### PR DESCRIPTION
### Fixed failing tests on GitHub Actions (CI/Test_DEV) [ Close #812 ]
Fixed failing issues in tests for `email.spec.js` and `adminInvitation.spec.js`. The main problem was that creating and logging in **more than two users** in `auth.spec.js `caused issues in these two tests.

- [x] Rewrited `auth.spec.js` test: located at **[src/test/integration/controllers/auth.spec.js](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/pull/816/files#diff-585b6d65828326221b8ca59272eadddf3af9acebb6e78b5766e5ae6bc2589a69)**
- [x] Rewrited `token.spec.js` test: located at **[src/test/unit/services/token.spec.js](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/pull/816/files#diff-0bef3e4ac3d15949c350bff746340c39f83b34786e5ad33ef3621df83ddbb5c2)**

**Before update:**
<img width="1041" alt="Screenshot 2024-07-04 at 01 39 53" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/28622400/c2f2a97a-a7a2-4b17-a65d-0cf0014992be">

**After update:**
<img width="526" alt="Screenshot 2024-07-04 at 23 58 39" src="https://github.com/ita-social-projects/SpaceToStudy-BackEnd/assets/28622400/cf37b595-b137-4962-8fa9-6387308d73b5">
