### PR TITLE
Resolved issue with Date availability field type in cooperation resource #820

### DIFF
--- a/src/consts/validation.js
+++ b/src/consts/validation.js
@@ -28,7 +28,7 @@ const enums = {
   QUIZ_VIEW_ENUM: ['Stepper', 'Scroll'],
   QUIZ_SETTINGS_ENUM: ['view', 'shuffle', 'pointValues', 'scoredResponses', 'correctAnswers'],
   RESOURCE_STATUS_ENUM: ['available', 'finished'],
-  RESOURCE_AVAILABILITY_STATUS_ENUM: ['open', 'closed'],
+  RESOURCE_AVAILABILITY_STATUS_ENUM: ['open', 'closed', 'openFrom'],
   RESOURCES_TYPES_ENUM: ['lessons', 'attachments', 'questions', 'quizzes']
 }
 


### PR DESCRIPTION
### Resolved issue with Date availability field type in cooperation resource [ Close #820 ]

Previously, when **updating the availability of a resource** for a specific date and attempting to save, the user was not presented with any feedback or error message. However, an `AxiosError` with code '`ERR_BAD_REQUEST`' was logged in the console, indicating a bad request error: 
<img width="1575" alt="Screenshot 2024-07-15 at 17 37 12" src="https://github.com/user-attachments/assets/42cf65ee-b599-4b16-b8b1-5802c0949d74">

Now, after changing the availability status of cooperation resources to a specific date and saving, the correct availability status is saved into the database:
<img width="765" alt="Screenshot 2024-07-15 at 19 21 04" src="https://github.com/user-attachments/assets/4a9141d4-e950-4c63-bff7-f1cbdf06cadb">
