### PR TITLE
Refactored cooperation model #788

### DIFF
--- a/src/middlewares/coopSectionsValidation.js
+++ b/src/middlewares/coopSectionsValidation.js
@@ -7,19 +7,7 @@ const validateLesson = require('~/utils/cooperations/sections/validateLesson')
 const validateQuiz = require('~/utils/cooperations/sections/validateQuiz')
 const deleteNotAllowedFields = require('~/utils/cooperations/sections/deleteNotAllowedFields')
 
-const activitieAllowedFields = ['resourceType', 'resource']
-
-const createActivitiesAndValidate = (activities) => {
-  if (Array.isArray(activities)) {
-    for (const activity of activities) {
-      const data = { ...activity }
-      activity.resource = { ...activity }
-      activity.resourceType = data.resourceType
-
-      validateActivity(activity)
-    }
-  }
-}
+const activityAllowedFields = ['resourceType', 'resource']
 
 const coopSectionsValidation = (req, _res, next) => {
   const { sections } = req.body
@@ -29,9 +17,6 @@ const coopSectionsValidation = (req, _res, next) => {
         for (const activity of section.activities) {
           validateActivity(activity)
         }
-      } else if (section.quizzes.length || section.lessons.length || section.attachments.length) {
-        section.activities = [...section.attachments, ...section.quizzes, ...section.lessons]
-        createActivitiesAndValidate(section.activities)
       }
     }
   }
@@ -43,7 +28,7 @@ const validateActivity = (activity) => {
   if (typeof activity.resource !== 'object' || Array.isArray(activity.resource)) {
     throw createError(400, FIELD_IS_NOT_OF_PROPER_TYPE('activity resource', 'object'))
   }
-  deleteNotAllowedFields(activity, activitieAllowedFields)
+  deleteNotAllowedFields(activity, activityAllowedFields)
 
   switch (activity.resourceType) {
     case QUIZZES:

--- a/src/models/cooperation.js
+++ b/src/models/cooperation.js
@@ -111,9 +111,6 @@ const cooperationSchema = new Schema(
           minLength: [1, FIELD_CANNOT_BE_SHORTER('section description', 1)],
           maxLength: [1000, FIELD_CANNOT_BE_LONGER('section description', 1000)]
         },
-        order: {
-          type: [String]
-        },
         activities: [
           {
             _id: false,

--- a/src/test/integration/controllers/cooperation.spec.js
+++ b/src/test/integration/controllers/cooperation.spec.js
@@ -92,9 +92,7 @@ const updatingSections = [
     _id: '65bc2bec67c9f1ec287a1514',
     title: 'Updated Section',
     description: 'This is the updated section description',
-    quizzes: [],
-    lessons: [],
-    attachments: []
+    activities: []
   }
 ]
 
@@ -103,7 +101,6 @@ const updatedSections = [
     _id: '65bc2bec67c9f1ec287a1514',
     title: 'Updated Section',
     description: 'This is the updated section description',
-    order: [],
     activities: []
   }
 ]

--- a/src/test/unit/middlewares/coopSectionsValidation.spec.js
+++ b/src/test/unit/middlewares/coopSectionsValidation.spec.js
@@ -8,28 +8,33 @@ jest.mock('~/utils/cooperations/sections/validateAttachment')
 jest.mock('~/utils/cooperations/sections/validateLesson')
 jest.mock('~/utils/cooperations/sections/validateQuiz')
 
-const quizMock = [
-  {
+const quizMock = {
+  resource: {
     title: 'Title',
     text: 'Text',
     availability: { status: 'open', date: null },
-    answers: [{ text: 'Answer 1', isCorrect: true }],
-    resourceType: QUIZZES
-  }
-]
+    answers: [{ text: 'Answer 1', isCorrect: true }]
+  },
+  resourceType: QUIZZES
+}
 
-const attachmentMock = [
-  {
+const attachmentMock = {
+  resource: {
     title: 'Title.png',
     link: '5534-Title.png',
-    availability: { status: 'open', date: null },
-    resourceType: ATTACHMENTS
-  }
-]
+    availability: { status: 'open', date: null }
+  },
+  resourceType: ATTACHMENTS
+}
 
-const lessonMock = [
-  { title: 'Title', availability: { status: 'open', date: null }, content: 'Content', resourceType: LESSONS }
-]
+const lessonMock = {
+  resource: {
+    title: 'Title',
+    availability: { status: 'open', date: null },
+    content: 'Content'
+  },
+  resourceType: LESSONS
+}
 
 const next = jest.fn()
 
@@ -37,9 +42,17 @@ const req = {
   body: {
     sections: [
       {
-        lessons: lessonMock,
-        attachments: attachmentMock,
-        quizzes: quizMock
+        activities: [
+          {
+            lessonMock
+          },
+          {
+            attachmentMock
+          },
+          {
+            quizMock
+          }
+        ]
       }
     ]
   }
@@ -65,9 +78,20 @@ describe('coopSectionsValidation', () => {
       body: {
         sections: [
           {
-            lessons: 'string',
-            attachments: 'string',
-            quizzes: 'string'
+            activities: [
+              {
+                resource: 'string',
+                resourceType: 'lessons'
+              },
+              {
+                resource: 'string',
+                resourceType: 'attachments'
+              },
+              {
+                resource: 'string',
+                resourceType: 'quizzes'
+              }
+            ]
           }
         ]
       }

--- a/src/test/unit/middlewares/coopSectionsValidation.spec.js
+++ b/src/test/unit/middlewares/coopSectionsValidation.spec.js
@@ -43,15 +43,9 @@ const req = {
     sections: [
       {
         activities: [
-          {
-            lessonMock
-          },
-          {
-            attachmentMock
-          },
-          {
-            quizMock
-          }
+          { resource: lessonMock.resource, resourceType: lessonMock.resourceType },
+          { resource: attachmentMock.resource, resourceType: attachmentMock.resourceType },
+          { resource: quizMock.resource, resourceType: quizMock.resourceType }
         ]
       }
     ]
@@ -79,18 +73,9 @@ describe('coopSectionsValidation', () => {
         sections: [
           {
             activities: [
-              {
-                resource: 'string',
-                resourceType: 'lessons'
-              },
-              {
-                resource: 'string',
-                resourceType: 'attachments'
-              },
-              {
-                resource: 'string',
-                resourceType: 'quizzes'
-              }
+              { resource: 'string', resourceType: 'lessons' },
+              { resource: 'string', resourceType: 'attachments' },
+              { resource: 'string', resourceType: 'quizzes' }
             ]
           }
         ]


### PR DESCRIPTION
### Refactored cooperation model [ Close #788 ]
Resources are now returned in a single array `activities`, combining `lessons`, `attachments`, and `quizzes`. The `order` field has also been removed as per requirements:
##
<img width="1251" alt="Screenshot 2024-07-25 at 23 56 01" src="https://github.com/user-attachments/assets/047b7d3b-72f0-4711-9488-a94b67cfc75e">

