### PR TITLE
Fixed missing resourceType in response on getting cooperation by ID #848

### DIFF
--- a/src/test/unit/utils/validateQuestion.spec.js
+++ b/src/test/unit/utils/validateQuestion.spec.js
@@ -13,7 +13,8 @@ describe('validateQuestion', () => {
       answers: [
         { text: 'Answer 1', isCorrect: true },
         { text: 'Answer 2', isCorrect: false }
-      ]
+      ],
+      type: 'openAnswer'
     }
   })
 

--- a/src/utils/cooperations/sections/validateAttachment.js
+++ b/src/utils/cooperations/sections/validateAttachment.js
@@ -1,11 +1,11 @@
-const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE } = require('~/consts/errors')
-const { ATTACHMENT } = require('~/consts/models')
-
 const { createError } = require('~/utils/errorsHelper')
 const validateCommonFields = require('~/utils/cooperations/sections/validateCommonFields')
 const deleteNotAllowedFields = require('./deleteNotAllowedFields')
 
-const allowedFields = ['_id', 'fileName', 'link', 'availability', 'size']
+const { ATTACHMENT } = require('~/consts/models')
+const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE } = require('~/consts/errors')
+
+const allowedFields = ['_id', 'fileName', 'link', 'size', 'resourceType', 'availability']
 
 const validateAttachment = (resource) => {
   deleteNotAllowedFields(resource, allowedFields)

--- a/src/utils/cooperations/sections/validateLesson.js
+++ b/src/utils/cooperations/sections/validateLesson.js
@@ -1,13 +1,14 @@
-const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE, FIELD_CAN_BE_ONE_OF } = require('~/consts/errors')
-const { LESSON } = require('~/consts/models')
-const {
-  enums: { RESOURCE_STATUS_ENUM }
-} = require('~/consts/validation')
 const { createError } = require('~/utils/errorsHelper')
 const validateCommonFields = require('~/utils/cooperations/sections/validateCommonFields')
 const deleteNotAllowedFields = require('./deleteNotAllowedFields')
 
-const allowedFields = ['_id', 'title', 'description', 'availability', 'attachments', 'content', 'status']
+const { LESSON } = require('~/consts/models')
+const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE, FIELD_CAN_BE_ONE_OF } = require('~/consts/errors')
+const {
+  enums: { RESOURCE_STATUS_ENUM }
+} = require('~/consts/validation')
+
+const allowedFields = ['_id', 'title', 'description', 'content', 'attachments', 'resourceType', 'availability']
 
 const validateLesson = (resource) => {
   deleteNotAllowedFields(resource, allowedFields)

--- a/src/utils/cooperations/sections/validateLesson.js
+++ b/src/utils/cooperations/sections/validateLesson.js
@@ -8,7 +8,16 @@ const {
   enums: { RESOURCE_STATUS_ENUM }
 } = require('~/consts/validation')
 
-const allowedFields = ['_id', 'title', 'description', 'content', 'attachments', 'resourceType', 'availability']
+const allowedFields = [
+  '_id',
+  'title',
+  'description',
+  'content',
+  'attachments',
+  'resourceType',
+  'availability',
+  'status'
+]
 
 const validateLesson = (resource) => {
   deleteNotAllowedFields(resource, allowedFields)

--- a/src/utils/cooperations/sections/validateQuestion.js
+++ b/src/utils/cooperations/sections/validateQuestion.js
@@ -1,12 +1,22 @@
-const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE } = require('~/consts/errors')
-
 const { createError } = require('~/utils/errorsHelper')
+const validateCommonFields = require('~/utils/cooperations/sections/validateCommonFields')
 const deleteNotAllowedFields = require('~/utils/cooperations/sections/deleteNotAllowedFields')
+
+const { QUESTION } = require('~/consts/models')
+const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE, FIELD_CAN_BE_ONE_OF } = require('~/consts/errors')
+const {
+  enums: { QUESTION_TYPE_ENUM }
+} = require('~/consts/validation')
 
 const answersFields = ['text', 'isCorrect']
 const textFields = ['title', 'text']
 
+const allowedFields = ['_id', 'title', 'text', 'answers', 'type', 'resourceType']
+
 const validateQuestion = (resource) => {
+  deleteNotAllowedFields(resource, allowedFields)
+  validateCommonFields(resource, QUESTION)
+
   for (const field of textFields) {
     if (!resource[field]) {
       throw createError(400, FIELD_IS_NOT_DEFINED(`quiz item ${field}`))
@@ -19,6 +29,14 @@ const validateQuestion = (resource) => {
 
   if (!resource.answers) {
     throw createError(400, FIELD_IS_NOT_DEFINED('quiz item answers'))
+  }
+
+  if (!resource.type) {
+    throw createError(400, FIELD_IS_NOT_DEFINED('quiz item type'))
+  }
+
+  if (!QUESTION_TYPE_ENUM.includes(resource.type)) {
+    throw createError(400, FIELD_CAN_BE_ONE_OF('quiz type', QUESTION_TYPE_ENUM))
   }
 
   validateAnswersFields(resource.answers)

--- a/src/utils/cooperations/sections/validateQuestion.js
+++ b/src/utils/cooperations/sections/validateQuestion.js
@@ -1,8 +1,6 @@
 const { createError } = require('~/utils/errorsHelper')
-const validateCommonFields = require('~/utils/cooperations/sections/validateCommonFields')
 const deleteNotAllowedFields = require('~/utils/cooperations/sections/deleteNotAllowedFields')
 
-const { QUESTION } = require('~/consts/models')
 const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE, FIELD_CAN_BE_ONE_OF } = require('~/consts/errors')
 const {
   enums: { QUESTION_TYPE_ENUM }
@@ -15,7 +13,6 @@ const allowedFields = ['_id', 'title', 'text', 'answers', 'type', 'resourceType'
 
 const validateQuestion = (resource) => {
   deleteNotAllowedFields(resource, allowedFields)
-  validateCommonFields(resource, QUESTION)
 
   for (const field of textFields) {
     if (!resource[field]) {

--- a/src/utils/cooperations/sections/validateQuiz.js
+++ b/src/utils/cooperations/sections/validateQuiz.js
@@ -1,14 +1,17 @@
-const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE, FIELD_CAN_BE_ONE_OF } = require('~/consts/errors')
-const { QUIZ } = require('~/consts/models')
-const {
-  enums: { RESOURCE_STATUS_ENUM, QUIZ_SETTINGS_ENUM }
-} = require('~/consts/validation')
-
 const { createError } = require('~/utils/errorsHelper')
 const deleteNotAllowedFields = require('~/utils/cooperations/sections/deleteNotAllowedFields')
 const validateCommonFields = require('~/utils/cooperations/sections/validateCommonFields')
 
+const { QUIZ } = require('~/consts/models')
+const { FIELD_IS_NOT_DEFINED, FIELD_IS_NOT_OF_PROPER_TYPE, FIELD_CAN_BE_ONE_OF } = require('~/consts/errors')
+const {
+  enums: { RESOURCE_STATUS_ENUM, QUIZ_SETTINGS_ENUM }
+} = require('~/consts/validation')
+
+const allowedFields = ['_id', 'title', 'description', 'items', 'resourceType', 'availability', 'settings']
+
 const validateQuiz = (resource) => {
+  deleteNotAllowedFields(resource, allowedFields)
   validateCommonFields(resource, QUIZ)
 
   if (typeof resource.settings !== 'object' || Array.isArray(resource.settings)) {

--- a/src/utils/cooperations/sections/validateQuiz.js
+++ b/src/utils/cooperations/sections/validateQuiz.js
@@ -8,7 +8,7 @@ const {
   enums: { RESOURCE_STATUS_ENUM, QUIZ_SETTINGS_ENUM }
 } = require('~/consts/validation')
 
-const allowedFields = ['_id', 'title', 'description', 'items', 'resourceType', 'availability', 'settings']
+const allowedFields = ['_id', 'title', 'description', 'items', 'resourceType', 'availability', 'settings', 'status']
 
 const validateQuiz = (resource) => {
   deleteNotAllowedFields(resource, allowedFields)


### PR DESCRIPTION
## Fixed missing resourceType in response on getting cooperation by ID [ Close #848 ]
To fix this problem, a thorough investigation was conducted on both the frontend and backend sides to find the reason for the missing `resourceType` in the response **when getting a cooperation by ID**. In the end, it _was found that the validation on the backend side for resources like `lesson` and `attachment` was cutting off a few fields_, including the `resourceType` field. To fix this issue, the validation was changed to allow the `resourceType` field to be included.

### Before changes:
After adding resources into cooperation with `resourceType` **lesson** or **attachment** and saving this cooperation, we try to refresh the page, but we can see that the icons for `lesson` and `attachment` are not proper. Also, in the response from the endpoint `http://localhost:3000/api/cooperations/:id`, we receive resources like `lesson` and `attachment` **without the `resourceType` field**, which **does exist for resources with type `quiz`**:
#
<img width="1555" alt="Screenshot 2024-08-06 at 15 15 58" src="https://github.com/user-attachments/assets/16ba46c6-694e-42c4-82e8-cb09b906243f">


### After changes: 
After reopening a cooperation after saving, we receive a response from the endpoint `http://localhost:3000/api/cooperations/:id` with `resourceType` for every resource, such as `lesson`, `attachment`, and `quiz`.  Additionally, it sets the proper icons for resources:
#
<img width="1555" alt="Screenshot 2024-08-06 at 15 49 49" src="https://github.com/user-attachments/assets/b765ab3e-10ef-437e-af51-9356283a4a08">
