### PR TITLE
Added isDuplicate field to resource models and updated get queries

### DIFF
--- a/docs/attachments/attachment.yaml
+++ b/docs/attachments/attachment.yaml
@@ -30,6 +30,12 @@ paths:
           schema:
             type: integer
           required: false
+        - in: query
+          name: includeDuplicates
+          schema:
+            type: boolean
+          required: false
+          description: If true will include in response attachments that have isDuplicate set to true. 
       responses:
         200:
           description: OK

--- a/docs/lesson/lesson.yaml
+++ b/docs/lesson/lesson.yaml
@@ -30,6 +30,12 @@ paths:
           schema:
             type: integer
           required: false
+        - in: query
+          name: includeDuplicates
+          schema:
+            type: boolean
+          required: false
+          description: If true will include in response lessons that have isDuplicate set to true. 
       responses:
         200:
           description: OK

--- a/docs/questions/question.yaml
+++ b/docs/questions/question.yaml
@@ -30,6 +30,12 @@ paths:
           schema:
             type: string
           required: false
+        - in: query
+          name: includeDuplicates
+          schema:
+            type: boolean
+          required: false
+          description: If true will include in response questions that have isDuplicate set to true. 
       responses:
         200:
           description: OK

--- a/docs/quiz/quiz.yaml
+++ b/docs/quiz/quiz.yaml
@@ -30,6 +30,12 @@ paths:
           schema:
             type: string
           required: false
+        - in: query
+          name: includeDuplicates
+          schema:
+            type: boolean
+          required: false
+          description: If true will include in response quizzes that have isDuplicate set to true. 
       responses:
         200:
           description: OK

--- a/src/controllers/attachment.js
+++ b/src/controllers/attachment.js
@@ -5,16 +5,18 @@ const getMatchOptions = require('~/utils/getMatchOptions')
 const getSortOptions = require('~/utils/getSortOptions')
 const getRegex = require('~/utils/getRegex')
 const getCategoriesOptions = require('~/utils/getCategoriesOption')
+const parseBoolean = require('../utils/parseBoolean')
 
 const getAttachments = async (req, res) => {
   const { id: author } = req.user
-  const { fileName, sort, skip, limit, categories } = req.query
+  const { fileName, sort, skip, limit, categories, includeDuplicates } = req.query
   const categoriesOptions = getCategoriesOptions(categories)
 
   const match = getMatchOptions({
     author,
     fileName: getRegex(fileName),
-    category: categoriesOptions
+    category: categoriesOptions,
+    isDuplicate: parseBoolean(includeDuplicates) ? null : { $ne: true }
   })
   const sortOptions = getSortOptions(sort)
 

--- a/src/controllers/attachment.js
+++ b/src/controllers/attachment.js
@@ -5,7 +5,7 @@ const getMatchOptions = require('~/utils/getMatchOptions')
 const getSortOptions = require('~/utils/getSortOptions')
 const getRegex = require('~/utils/getRegex')
 const getCategoriesOptions = require('~/utils/getCategoriesOption')
-const parseBoolean = require('../utils/parseBoolean')
+const parseBoolean = require('~/utils/parseBoolean')
 
 const getAttachments = async (req, res) => {
   const { id: author } = req.user

--- a/src/controllers/lesson.js
+++ b/src/controllers/lesson.js
@@ -3,7 +3,7 @@ const getCategoriesOptions = require('~/utils/getCategoriesOption')
 const getMatchOptions = require('~/utils/getMatchOptions')
 const getRegex = require('~/utils/getRegex')
 const getSortOptions = require('~/utils/getSortOptions')
-const parseBoolean = require('../utils/parseBoolean')
+const parseBoolean = require('~/utils/parseBoolean')
 
 const createLesson = async (req, res) => {
   const { id: author } = req.user

--- a/src/controllers/lesson.js
+++ b/src/controllers/lesson.js
@@ -3,6 +3,7 @@ const getCategoriesOptions = require('~/utils/getCategoriesOption')
 const getMatchOptions = require('~/utils/getMatchOptions')
 const getRegex = require('~/utils/getRegex')
 const getSortOptions = require('~/utils/getSortOptions')
+const parseBoolean = require('../utils/parseBoolean')
 
 const createLesson = async (req, res) => {
   const { id: author } = req.user
@@ -23,10 +24,15 @@ const getLessonById = async (req, res) => {
 
 const getLessons = async (req, res) => {
   const { id: author } = req.user
-  const { title, sort, skip, limit, categories } = req.query
+  const { title, sort, skip, limit, categories, includeDuplicates } = req.query
 
   const categoriesOptions = getCategoriesOptions(categories)
-  const match = getMatchOptions({ author, title: getRegex(title), category: categoriesOptions })
+  const match = getMatchOptions({
+    author,
+    title: getRegex(title),
+    category: categoriesOptions,
+    isDuplicate: parseBoolean(includeDuplicates) ? null : { $ne: true }
+  })
   const sortOptions = getSortOptions(sort)
 
   const lessons = await lessonService.getLessons(match, sortOptions, parseInt(skip), parseInt(limit))

--- a/src/controllers/question.js
+++ b/src/controllers/question.js
@@ -3,16 +3,18 @@ const getCategoriesOptions = require('~/utils/getCategoriesOption')
 const getMatchOptions = require('~/utils/getMatchOptions')
 const getRegex = require('~/utils/getRegex')
 const getSortOptions = require('~/utils/getSortOptions')
+const parseBoolean = require('../utils/parseBoolean')
 
 const getQuestions = async (req, res) => {
   const { id: author } = req.user
-  const { title, sort, skip, limit, categories } = req.query
+  const { title, sort, skip, limit, categories, includeDuplicates } = req.query
   const categoriesOptions = getCategoriesOptions(categories)
 
   const match = getMatchOptions({
     author,
     title: getRegex(title),
-    category: categoriesOptions
+    category: categoriesOptions,
+    isDuplicate: parseBoolean(includeDuplicates) ? null : { $ne: true }
   })
   const sortOptions = getSortOptions(sort)
 

--- a/src/controllers/question.js
+++ b/src/controllers/question.js
@@ -3,7 +3,7 @@ const getCategoriesOptions = require('~/utils/getCategoriesOption')
 const getMatchOptions = require('~/utils/getMatchOptions')
 const getRegex = require('~/utils/getRegex')
 const getSortOptions = require('~/utils/getSortOptions')
-const parseBoolean = require('../utils/parseBoolean')
+const parseBoolean = require('~/utils/parseBoolean')
 
 const getQuestions = async (req, res) => {
   const { id: author } = req.user

--- a/src/controllers/quiz.js
+++ b/src/controllers/quiz.js
@@ -3,7 +3,7 @@ const getCategoriesOptions = require('~/utils/getCategoriesOption')
 const getMatchOptions = require('~/utils/getMatchOptions')
 const getRegex = require('~/utils/getRegex')
 const getSortOptions = require('~/utils/getSortOptions')
-const parseBoolean = require('../utils/parseBoolean')
+const parseBoolean = require('~/utils/parseBoolean')
 
 const getQuizzes = async (req, res) => {
   const { id: author } = req.user

--- a/src/controllers/quiz.js
+++ b/src/controllers/quiz.js
@@ -3,13 +3,19 @@ const getCategoriesOptions = require('~/utils/getCategoriesOption')
 const getMatchOptions = require('~/utils/getMatchOptions')
 const getRegex = require('~/utils/getRegex')
 const getSortOptions = require('~/utils/getSortOptions')
+const parseBoolean = require('../utils/parseBoolean')
 
 const getQuizzes = async (req, res) => {
   const { id: author } = req.user
-  const { title, sort, skip, limit, categories } = req.query
+  const { title, sort, skip, limit, categories, includeDuplicates } = req.query
   const categoriesOptions = getCategoriesOptions(categories)
 
-  const match = getMatchOptions({ author, title: getRegex(title), category: categoriesOptions })
+  const match = getMatchOptions({
+    author,
+    title: getRegex(title),
+    category: categoriesOptions,
+    isDuplicate: parseBoolean(includeDuplicates) ? null : { $ne: true }
+  })
   const sortOptions = getSortOptions(sort)
 
   const quizzes = await quizService.getQuiz(match, sortOptions, parseInt(skip), parseInt(limit))

--- a/src/models/attachment.js
+++ b/src/models/attachment.js
@@ -51,6 +51,9 @@ const attachmentSchema = new Schema(
       },
       default: RESOURCES_TYPES_ENUM[2]
     },
+    isDuplicate: {
+      type: Boolean
+    },
     availability: {
       status: {
         type: String,

--- a/src/models/lesson.js
+++ b/src/models/lesson.js
@@ -54,6 +54,9 @@ const lessonSchema = new Schema(
       },
       default: RESOURCES_TYPES_ENUM[0]
     },
+    isDuplicate: {
+      type: Boolean
+    },
     availability: {
       status: {
         type: String,

--- a/src/models/question.js
+++ b/src/models/question.js
@@ -64,6 +64,9 @@ const questionSchema = new Schema(
         message: ENUM_CAN_BE_ONE_OF('resource type', RESOURCES_TYPES_ENUM)
       },
       default: RESOURCES_TYPES_ENUM[3]
+    },
+    isDuplicate: {
+      type: Boolean
     }
   },
   { timestamps: true, versionKey: false }

--- a/src/models/quiz.js
+++ b/src/models/quiz.js
@@ -46,6 +46,9 @@ const quizSchema = new Schema(
       },
       default: RESOURCES_TYPES_ENUM[1]
     },
+    isDuplicate: {
+      type: Boolean
+    },
     availability: {
       status: {
         type: String,


### PR DESCRIPTION
- [x] Added a boolean field `isDuplicate` to the following resource models: `Lesson`, `Quiz`, `Attachment`, and `Question`.
- [x] Updated the response from the endpoints `/lessons`, `/quizzes`,` /attachments`, and `/questions` to exclude resources with the existing field `isDuplicate: true`.

We can include resources with the existing field `isDuplicate: true` using new query param
![image](https://github.com/user-attachments/assets/c08e3c61-ad94-49a6-94db-51707143d708)
