### PR TITLE
Update prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jest-sonar-reporter": "^2.0.0",
     "lint-staged": "^13.0.2",
     "nodemon": "^2.0.15",
-    "prettier": "2.5.1",
+    "prettier": "^3.3.3",
     "supertest": "^7.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
- [x] Update `prettier` from `v2.5.1` to `v3.3.3`

# Breaking Changes:
- Node.js Version: Minimum required version is now v14.
- Public APIs: All public APIs are now asynchronous.
- Default Value Change: trailingComma default value changed to "all".
### Plugin System:
- Embed method of a printer has a new signature.
- Parsers.parse no longer accepts the second argument.
- Prettier.doc.builders.concat has been removed.
- TextToDoc now trims trailing hard lines.
- Package File Structure: Updated, with an exports field added to package.json (specific to 3.0.0-alpha.1).

Full changelog [here](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)