### PR TITLE
Update jsonwebtoken

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express": "^4.17.1",
     "googleapis": "^105.0.0",
     "iconv-lite": "^0.6.3",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.2",
     "module-alias": "^2.2.2",
     "mongodb": "^4.2.2",
     "mongoose": "^6.1.2",


### PR DESCRIPTION
- [x] Update `jsonwebtoken` from `v8.5.1` to `v9.0.2`
### Breaking changes:
### 9.0.0
- Removed support for Node versions 11 and below.
- The verify() function no longer accepts unsigned tokens by default.
- RSA key size must be 2048 bits or greater.
- Key types must be valid for the signing / verification algorithm

[Changelog](https://github.com/auth0/node-jsonwebtoken/blob/master/CHANGELOG.md)
[Migration Notes: v8 to v9](https://github.com/auth0/node-jsonwebtoken/wiki/Migration-Notes:-v8-to-v9)