### PR TITLE
Update email-templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cors": "^2.8.5",
     "cron": "^2.1.0",
     "dotenv": "^10.0.0",
-    "email-templates": "^10.0.0",
+    "email-templates": "^12.0.1",
     "express": "^4.17.1",
     "googleapis": "^105.0.0",
     "iconv-lite": "^0.6.3",


### PR DESCRIPTION
- [x] Update `email-templates` from `v10.0.0` to `v12.0.1`
### Breaking changes:
### v12.0.0
- The `preview-email` dependency is now an optional dependency. You will need to `npm install preview-email` or set `preview: false`, otherwise an error will be thrown in non-production environments and console.error in production environments if `preview` option is a truthy value. The default value for `preview` is `preview: process.NODE_ENV === 'development'`.
### v11.0.0
- No longer inlines stylesheets by default and preserves `<style>` tags in the `<head>`

Full breaking chages changelog [here](https://github.com/forwardemail/email-templates?tab=readme-ov-file#breaking-changes) 