### PR TITLE
Resolved BSONTypeError when adding duplicate resources to Course/Cooperation

### DIFF
--- a/src/utils/handleResources.js
+++ b/src/utils/handleResources.js
@@ -14,8 +14,6 @@ const handleResources = async (resources) => {
         return cleanedResource
       }
 
-      let newResource = resource
-
       if (_id) {
         const existingResource = await resourceModelMapping[resourceType].findOne({
           _id,
@@ -25,13 +23,11 @@ const handleResources = async (resources) => {
         if (existingResource) {
           return { ...resourceItem, resource: existingResource }
         }
-
-        newResource = removeMetadataFields(resource)
-      } else {
-        newResource = removeMetadataFields(resource)
       }
 
+      const newResource = removeMetadataFields(resource)
       const createdResource = await resourceModelMapping[resourceType].create({ ...newResource, isDuplicate })
+
       return { ...resourceItem, resource: createdResource }
     })
   )


### PR DESCRIPTION
## Fixed "Cast to ObjectId failed" error when adding duplicate resource to `Course` & `Cooperation` and fixed incorrect timestamps on duplicated resources [ Close #888 , Close #889 ]

Previously, when adding a resource as a duplicate copy to a `Course` or `Cooperation` and trying to `Save`, a "`Cast to ObjectId failed`" error occurs due to a `BSONTypeError`. This issue prevented the resource from being properly saved in the database :
<img width="968" alt="backend error" src="https://github.com/user-attachments/assets/e973078e-e208-4022-a960-3820f037be75">

Also, when a resource was duplicated, the `createdAt` and `updatedAt` timestamps did not reflect the time of duplication because they were copying the original resource's timestamps, leading to inaccurate timestamps. To resolve this issue, I omitted the `createdAt` and `updatedAt` timestamps during the duplication process, allowing MongoDB to create new, correct dates automatically

**Before changes:**
<img width="1158" alt="database fix" src="https://github.com/user-attachments/assets/fc17e276-2e35-4803-8c5a-c6b538bbb663">

**After changes:**
The timestamps accurately represent the creation and last update times of the duplicated resource.
<img width="980" alt="Screenshot 2024-08-27 at 11 53 42" src="https://github.com/user-attachments/assets/2edc4472-5850-4471-af7e-c1b823517ce6">


