### PR TITLE
Delete course with duplicated resources

### DIFF
--- a/src/utils/deleteDuplicateResources.js
+++ b/src/utils/deleteDuplicateResources.js
@@ -1,0 +1,33 @@
+const resourceModelMapping = require('~/utils/resourceModelMapping')
+
+const deleteDuplicateResources = async (course) => {
+  const resourceIdsMapping = extractDuplicateResourceIds(course)
+
+  const deletePromises = Object.entries(resourceIdsMapping).map(([resourceType, ids]) => {
+    return resourceModelMapping[resourceType].deleteMany({ _id: { $in: ids } }).exec()
+  })
+
+  await Promise.all(deletePromises)
+}
+
+const extractDuplicateResourceIds = (course) => {
+  const resourceIdsMapping = {}
+
+  course.sections.forEach((section) => {
+    section.resources.forEach(({ resource }) => {
+      const { _id, isDuplicate, resourceType } = resource
+
+      if (!isDuplicate) return
+
+      if (Array.isArray(resourceIdsMapping[resourceType])) {
+        resourceIdsMapping[resourceType].push(_id)
+      } else {
+        resourceIdsMapping[resourceType] = [_id]
+      }
+    })
+  })
+
+  return resourceIdsMapping
+}
+
+module.exports = deleteDuplicateResources


### PR DESCRIPTION
### Enhanced the course deletion process
This PR enhances the existing course deletion logic by ensuring that any duplicated resources associated with the course are properly identified and removed.

- [x] Ensures that all duplicated resources are cleaned up before a course is deleted, preventing orphaned or unnecessary data in the database.
- [x] Improves the maintainability and clarity of the codebase by separating concerns into distinct functions.