### PR TITLE
Removed the "availability" field from the Lesson, Quiz, Attachment entities #903

### DIFF
--- a/docs/cooperation/cooperation-schema.yaml
+++ b/docs/cooperation/cooperation-schema.yaml
@@ -41,6 +41,83 @@ definitions:
         updatedAt:
           type: string
           format: date-time
+  cooperation:
+    type: object
+    properties:
+      _id:
+        type: string
+      offer:
+        type: string
+        ref: '#components/offer'
+      initiator:
+        type: string
+        ref: '#/components/user'
+      initiatorRole:
+        type: string
+      receiver:
+        type: string
+        ref: '#components/user'
+      receiverRole:
+        type: string
+      price:
+        type: number
+      title:
+        type: string
+      status:
+        type: string
+        enum:
+          - pending
+          - active
+          - declined
+          - closed
+      sections:
+        type: array
+        items:
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            resources:
+              type: array
+              items:
+                type: object
+                properties:
+                  resource:
+                    type: object
+                    additionalProperties: true
+                  resourceType:
+                    type: string
+                    enum:
+                      - lesson
+                      - quiz
+                      - attachment
+                  availability:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - open
+                          - closed
+                          - openFrom
+                        default: open
+                      date:
+                        type: string
+                        format: date-time
+                        default: null
+      needAction:
+        type: string
+        enum:
+          - student
+          - tutor
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
   cooperationBody:
     type: object
     properties:
@@ -66,80 +143,365 @@ definitions:
         items:
           type: object
           properties:
-          title: string
-          description: string
-          resources:
-            type: array
-            items:
-              type: object
-              properties:
-                resource:
-                  type: object
-                  additionalProperties: true
-                resourceType:
-                  type: string
-                  enum:
-                    - lesson
-                    - quiz
-                    - attachment
-  cooperation:
+            title:
+              type: string
+            description:
+              type: string
+            resources:
+              type: array
+              items:
+                type: object
+                properties:
+                  resource:
+                    type: object
+                    additionalProperties: true
+                  resourceType:
+                    type: string
+                    enum:
+                      - lesson
+                      - quiz
+                      - attachment
+                  availability:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - open
+                          - closed
+                          - openFrom
+                        default: open
+                      date:
+                        type: string
+                        format: date-time
+                        default: null
+  cooperationResponse:
     type: object
     properties:
       _id:
         type: string
       offer:
-        type: string
-        ref: '#components/offer'
+        type: object
+        properties:
+          _id:
+            type: string
+          proficiencyLevel:
+            type: array
+            items:
+              type: string
+          title:
+            type: string
+          description:
+            type: string
+          languages:
+            type: array
+            items:
+              type: string
+          author:
+            type: object
+            properties:
+              totalReviews:
+                type: object
+                properties:
+                  student:
+                    type: integer
+                  tutor:
+                    type: integer
+              averageRating:
+                type: object
+                properties:
+                  student:
+                    type: number
+                  tutor:
+                    type: number
+              _id:
+                type: string
+              firstName:
+                type: string
+              lastName:
+                type: string
+              photo:
+                type: string
+              professionalSummary:
+                type: string
+          subject:
+            type: object
+            properties:
+              _id:
+                type: string
+              name:
+                type: string
+          category:
+            type: object
+            properties:
+              appearance:
+                type: object
+                properties:
+                  color:
+                    type: string
+                  icon:
+                    type: string
+              _id:
+                type: string
+              name:
+                type: string
       initiator:
-        type: string
-        ref: '#/components/user'
+        type: object
+        properties:
+          address:
+            type: object
+            properties:
+              country:
+                type: string
+              city:
+                type: string
+          mainSubjects:
+            type: object
+            properties:
+              student:
+                type: array
+                items:
+                  type: string
+              tutor:
+                type: array
+                items:
+                  type: string
+          totalReviews:
+            type: object
+            properties:
+              student:
+                type: integer
+              tutor:
+                type: integer
+          averageRating:
+            type: object
+            properties:
+              student:
+                type: number
+              tutor:
+                type: number
+          status:
+            type: object
+            properties:
+              student:
+                type: string
+              tutor:
+                type: string
+              admin:
+                type: string
+          videoLink:
+            type: object
+            properties:
+              student:
+                type: string
+          professionalBlock:
+            type: object
+            properties:
+              awards:
+                type: string
+              scientificActivities:
+                type: string
+              workExperience:
+                type: string
+              education:
+                type: string
+          notificationSettings:
+            type: object
+            properties:
+              isOfferStatusNotification:
+                type: boolean
+              isChatNotification:
+                type: boolean
+              isSimilarOffersNotification:
+                type: boolean
+              isEmailNotification:
+                type: boolean
+          _id:
+            type: string
+          role:
+            type: array
+            items:
+              type: string
+          firstName:
+            type: string
+          lastName:
+            type: string
+          email:
+            type: string
+          nativeLanguage:
+            type: string
+          lastLogin:
+            type: string
+          createdAt:
+            type: string
+          updatedAt:
+            type: string
+          professionalSummary:
+            type: string
       initiatorRole:
         type: string
       receiver:
-        type: string
-        ref: '#components/user'
+        type: object
+        properties:
+          address:
+            type: object
+            properties:
+              country:
+                type: string
+              city:
+                type: string
+          mainSubjects:
+            type: object
+            properties:
+              student:
+                type: array
+                items:
+                  type: string
+              tutor:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    category:
+                      type: string
+                    subjects:
+                      type: array
+                      items:
+                        type: string
+                    _id:
+                      type: string
+          totalReviews:
+            type: object
+            properties:
+              student:
+                type: integer
+              tutor:
+                type: integer
+          averageRating:
+            type: object
+            properties:
+              student:
+                type: number
+              tutor:
+                type: number
+          status:
+            type: object
+            properties:
+              student:
+                type: string
+              tutor:
+                type: string
+              admin:
+                type: string
+          videoLink:
+            type: object
+            properties:
+              tutor:
+                type: string
+          professionalBlock:
+            type: object
+            properties:
+              awards:
+                type: string
+              scientificActivities:
+                type: string
+              workExperience:
+                type: string
+              education:
+                type: string
+          notificationSettings:
+            type: object
+            properties:
+              isOfferStatusNotification:
+                type: boolean
+              isChatNotification:
+                type: boolean
+              isSimilarOffersNotification:
+                type: boolean
+              isEmailNotification:
+                type: boolean
+          _id:
+            type: string
+          role:
+            type: array
+            items:
+              type: string
+          firstName:
+            type: string
+          lastName:
+            type: string
+          email:
+            type: string
+          nativeLanguage:
+            type: string
+          lastLogin:
+            type: string
+          createdAt:
+            type: string
+          updatedAt:
+            type: string
+          photo:
+            type: string
+          professionalSummary:
+            type: string
       receiverRole:
         type: string
-      price:
-        type: number
-      title: 
+      title:
         type: string
+      proficiencyLevel:
+        type: string
+      price:
+        type: integer
       status:
         type: string
-        enum:
-          - pending
-          - active
-          - declined
-          - closed
+      needAction:
+        type: string
+      availableQuizzes:
+        type: array
+        items:
+          type: string
+      finishedQuizzes:
+        type: array
+        items:
+          type: string
       sections:
         type: array
         items:
           type: object
           properties:
-          title: string
-          description: string
-          resources:
-            type: array
-            items:
-              type: object
-              properties:
-                resource:
-                  type: object
-                  additionalProperties: true
-                resourceType:
-                  type: string
-                  enum:
-                    - lesson
-                    - quiz
-                    - attachment
-      needAction:
-        type: string
-        enum:
-          - student
-          - tutor
+            title:
+              type: string
+            description:
+              type: string
+            resources:
+              type: array
+              items:
+                type: object
+                properties:
+                  resource:
+                    type: object
+                    additionalProperties: true
+                  resourceType:
+                    type: string
+                    enum:
+                      - lesson
+                      - quiz
+                      - attachment
+                  availability:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - open
+                          - closed
+                          - openFrom
+                        default: open
+                      date:
+                        type: string
+                        format: date-time
+                        default: null
       createdAt:
         type: string
-        format: date-time
       updatedAt:
         type: string
-        format: date-time

--- a/docs/cooperation/cooperation.yaml
+++ b/docs/cooperation/cooperation.yaml
@@ -23,10 +23,14 @@ paths:
                   initiatorRole: tutor
                   receiver: 6255bc080a75adf9223df100
                   receiverRole: student
-                  price: 200
                   title: 'Violin lessons'
+                  proficiencyLevel: Intermediate
+                  price: 200
                   status: active
                   needAction: student
+                  availableQuizzes: []
+                  finishedQuizzes: []
+                  sections: []
                   createdAt: 2021-05-09T11:34:53.243+00:00
                   updatedAt: 2022-07-02T11:59:53.243+00:00
                 - _id: 63ebc6fbd2f34037d0aba314
@@ -35,10 +39,14 @@ paths:
                   initiatorRole: tutor
                   receiver: 6255bc080a75adf9223df100
                   receiverRole: student
-                  price: 300
                   title: 'Violin lessons'
+                  proficiencyLevel: Intermediate
+                  price: 300
                   status: closed
                   needAction: tutor
+                  availableQuizzes: []
+                  finishedQuizzes: []
+                  sections: []
                   createdAt: 2021-04-09T11:34:53.243+00:00
                   updatedAt: 2022-09-02T11:59:53.243+00:00
         401:
@@ -46,7 +54,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/cooperations/Error'
+                $ref: '#/components/Error'
               example:
                 status: 401
                 code: 'UNAUTHORIZED'
@@ -86,10 +94,14 @@ paths:
                 initiatorRole: tutor
                 receiver: 6255bc080a75adf9223df100
                 receiverRole: student
-                price: 300
                 title: 'Violin lessons'
+                proficiencyLevel: Intermediate
+                price: 300
                 status: pending
                 needAction: student
+                availableQuizzes: []
+                finishedQuizzes: []
+                sections: []
                 createdAt: 2021-04-09T11:34:53.243+00:00
                 updatedAt: 2022-09-02T11:59:53.243+00:00
         400:
@@ -127,7 +139,8 @@ paths:
           in: path
           required: true
           description: ID of the cooperation that needs to be fetched
-          type: string
+          schema:
+            type: string
       responses:
         200:
           description: OK
@@ -137,125 +150,162 @@ paths:
                 $ref: '#/definitions/cooperationResponse'
               example:
                 _id: 8755bc080a00adr9243df106
-                offer: 63ebc6fbd2f34037d0aba791
+                offer:
+                  _id: 63ebc6fbd2f34037d0aba791
+                  proficiencyLevel:
+                    - Intermediate
+                    - Advanced
+                    - Test Preparation
+                    - Professional
+                  title: 'Understanding Quadratic Equations'
+                  description: "In this lesson, we will delve into the world of quadratic equations. We'll explore the standard form of a quadratic equation, learn how to identify the coefficients, and understand the significance of the discriminant. Students will also practice solving quadratic equations using various methods, including factoring, completing the square, and the quadratic formula. By the end of the lesson, students will be able to solve quadratic equations confidently and understand their graphical representations."
+                  languages:
+                    - English
+                  author:
+                    totalReviews:
+                      student: 0
+                      tutor: 0
+                    averageRating:
+                      student: 0
+                      tutor: 0
+                    _id: 6658f73f93885febb491e08b
+                    firstName: 'John'
+                    lastName: 'Doe'
+                    photo: '6658f73f93885-test_student.png'
+                    professionalSummary: 'I am student of the University of Cambridge. I am passionate about learning mathematics.'
+                  subject:
+                    _id: 6566133a2bccdd3e18dbe943
+                    name: 'Algebra'
+                  category:
+                    appearance:
+                      color: '#E3B21C'
+                      icon: 'TagRoundedIcon'
+                    _id: '64884f33fdc2d1a130c24ac2'
+                    name: 'Mathematics'
                 initiator:
-                  - _id: 6255bc080a75adf9223df100
-                    role: [student, tutor]
-                    firstName: John
-                    lastName: Doe
-                    email: johndoe@gmail.com
-                    mainSubjects:
-                      {
-                        student:
-                          [
-                            {
-                              _id: 64593435163b62124ce4c3ab,
-
-                              category: { _id: '6421ed8ed991d46a84721df2', name: Cybersecurity },
-                              subjects: [{ _id: '6421ed8ed991d46a84721df2', name: 'XSS Attack' }],
-                              isDeletionBlocked: false
-                            },
-                            {
-                              _id: 64593435263b62124ce4c3ck,
-                              category: { _id: '6421ed8ed991d46a84721dfa', name: music },
-                              subjects: [{ _id: '6422d995d898aa732d038e8f', name: 'Guitar' }],
-                              isDeletionBlocked: true
-                            }
-                          ],
-                        tutor:
-                          [
-                            {
-                              _id: 64593435163b62124ce4c3ab,
-
-                              category: { _id: '6421ed8ed991d46a84721df2', name: Cybersecurity },
-                              subjects: [{ _id: '6421ed8ed991d46a84721df2', name: 'XSS Attack' }],
-                              isDeletionBlocked: false
-                            }
-                          ]
-                      }
-                    totalReviews: { student: 10, tutor: 8 }
-                    averageRating: { student: 4.5, tutor: 4.9 }
-                    nativeLanguage: english
-                    address: { country: The USA, city: California }
-                    professionalSummary: KNPU H.S. Skovoroda
-                    photo: john-doe-photo.jpg
-                    status: { student: active, tutor: active, admin: active }
-                    lastLogin: null
-                    FAQ:
-                      {
-                        student: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }],
-                        tutor: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }]
-                      }
-                    videoLink:
-                      { student: www.youtube.com/watch?v=ebTnuLRnIOY, tutor: www.youtube.com/watch?v=ebTnuLRnIOY }
-                    createdAt: 2021-04-09T11:34:53.243+00:00
-                    updatedAt: 2022-09-02T11:59:53.243+00:00
-                initiatorRole: student
+                  address:
+                    country: 'USA'
+                    city: 'California'
+                  mainSubjects:
+                    student: []
+                    tutor: []
+                  totalReviews:
+                    student: 8
+                    tutor: 7.5
+                  averageRating:
+                    student: 5
+                    tutor: 4.9
+                  status:
+                    student: 'active'
+                    tutor: 'active'
+                    admin: 'active'
+                  videoLink:
+                    student: 'https://www.youtube.com/watch?v=ebTnuLRnIOY-JohnDoe'
+                  professionalBlock:
+                    awards: 'Gold medal in mathematics competition'
+                    scientificActivities: 'Founded the Math Club at the University of Cambridge'
+                    workExperience: 'n/a'
+                    education: 'Working towards a Bachelor of Mathematics at the University of Cambridge'
+                  notificationSettings:
+                    isOfferStatusNotification: true
+                    isChatNotification: true
+                    isSimilarOffersNotification: true
+                    isEmailNotification: true
+                  _id: 6658f6b793885febb491e07c
+                  role:
+                    - 'student'
+                  firstName: 'John'
+                  lastName: 'Doe'
+                  email: 'john_doe@gmail.com'
+                  nativeLanguage: English
+                  lastLogin: '2024-08-06T13:47:50.872Z'
+                  createdAt: '2024-05-30T21:59:19.434Z'
+                  updatedAt: '2024-08-06T13:47:50.872Z'
+                  professionalSummary: 'I am a student at the University of Cambridge studying Mathematics. I am passionate about learning mathematics.'
+                initiatorRole: 'student'
                 receiver:
-                  - _id: 8755bc080a00adr9243df104
-                    role: [tutor]
-                    firstName: Joe
-                    lastName: Doe
-                    email: joedoe@outlook.com
-                    mainSubjects:
-                      {
-                        tutor:
-                          [
-                            {
-                              _id: 64593435163b62124ce4c3ab,
-
-                              category: { _id: '6421ed8ed991d46a84721df2', name: Cybersecurity },
-                              subjects: [{ _id: '6421ed8ed991d46a84721df2', name: 'XSS Attack' }],
-                              isDeletionBlocked: false
-                            }
-                          ],
-                        student: []
-                      }
-                    totalReviews: { student: 0, tutor: 530 }
-                    averageRating: { student: 0, tutor: 5 }
-                    nativeLanguage: ukrainian
-                    address: { country: Ukraine, city: Kharkiv }
-                    professionalSummary: KNPU H.S. Skovoroda
-                    photo: joe-doe-photo.jpg
-                    status: { student: active, tutor: active, admin: active }
-                    FAQ:
-                      {
-                        student:
-                          [{ question: student question, _id: 63525e23bf163f5ea609ff2b, answer: student answer }],
-                        tutor: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }]
-                      }
-                    videoLink: { tutor: www.youtube.com/watch?v=ebTnuLRnIOY }
-                    lastLogin: 2022-09-02T11:59:53.243+00:00
-                    createdAt: 2021-04-09T11:34:53.243+00:00
-                    updatedAt: 2022-09-02T11:59:53.243+00:00
-                receiverRole: tutor
+                  address:
+                    country: 'USA'
+                    city: 'Massachusetts'
+                  mainSubjects:
+                    student: []
+                    tutor:
+                      - category: '64884f4dfdc2d1a130c24ac6'
+                        subjects:
+                          - '6675874d59019cd05eb11a16'
+                          - '65660fbbcb972798c401a9b4'
+                        _id: '6675a09d83835d79e960087a'
+                      - category: '64884f98fdc2d1a130c24ad4'
+                        subjects:
+                          - '66758d6e59019cd05eb11a5d'
+                        _id: '6675a08e83835d79e9600842'
+                      - category: '64884f33fdc2d1a130c24ac2'
+                        subjects:
+                          - '6566133a2bccdd3e18dbe943'
+                        _id: '6675a06f83835d79e96007fc'
+                  totalReviews:
+                    student: 10
+                    tutor: 8
+                  averageRating:
+                    student: 4.5
+                    tutor: 4.9
+                  status:
+                    student: 'active'
+                    tutor: 'active'
+                    admin: 'active'
+                  videoLink:
+                    tutor: 'https://www.youtube.com/watch?v=ebTnuLRnIOY-JaneRoe'
+                  professionalBlock:
+                    awards: 'The best tutor of the year 2023'
+                    scientificActivities: "The author of the scientific work 'The role of mathematics in the development of society'"
+                    workExperience: 'I have been tutoring students in Mathematics for over 5 years and have helped many students achieve their academic goals.'
+                    education: 'The University of Cambridge, Bachelor of Mathematics'
+                  notificationSettings:
+                    isOfferStatusNotification: true
+                    isChatNotification: true
+                    isSimilarOffersNotification: true
+                    isEmailNotification: true
+                  _id: 6658f73f93885febb491e08b
+                  role:
+                    - 'tutor'
+                  firstName: 'Jane'
+                  lastName: 'Roe'
+                  email: 'jane_roe@gmail.com'
+                  nativeLanguage: null
+                  lastLogin: '2024-09-06T21:08:58.254Z'
+                  createdAt: '2024-05-30T22:01:35.360Z'
+                  updatedAt: '2024-09-06T21:08:58.256Z'
+                  photo: '6658f73f938-test_tutor.png'
+                  professionalSummary: 'Recently graduated from the University of Cambridge with a degree in Mathematics. I have been tutoring students in Mathematics for over 5 years and have helped many students achieve their academic goals. I am passionate about teaching and enjoy helping students understand complex mathematical concepts. I believe that every student has the potential to succeed and I am committed to helping them reach their full potential.'
+                receiverRole: 'tutor'
+                title: 'Understanding Quadratic Equations'
+                proficiencyLevel: 'Intermediate'
                 price: 150
-                title: 'Violin lessons'
-                status: pending
+                status: 'active'
+                needAction: 'tutor'
+                availableQuizzes: []
+                finishedQuizzes: []
                 sections:
-                  {
-                    title: Section title,
-                    description: Section description,
+                  - title: Section title
+                    description: Section description
                     resources:
-                      [
-                        {
-                          resource:
-                            {
-                              title: Colors in English,
-                              description: With this lesson you will learn all about colors in English.,
-                              content: <h1>Title</h1>,
-                              author: 63da8767c9ad4c9a0b0eacd3,
-                              attachments: [63ed1cd25e9d781cdb6a6b15],
-                              category: { _id: 6477007a6fa4d05e1a800ce1, name: Languages },
-                              _id: 63ed1cd25e9d781cdb6a6b17
-                            },
-                          resourceType: lesson
-                        }
-                      ]
-                  }
-                needAction: student
-                createdAt: 2022-10-18T13:25:36.292+00:00
-                updatedAt: 2022-10-18T13:25:36.292+00:00
+                      - resource:
+                          title: Colors in English
+                          description: With this lesson you will learn all about colors in English.
+                          content: <h1>Title</h1>
+                          author: 63da8767c9ad4c9a0b0eacd3
+                          attachments:
+                            - 63ed1cd25e9d781cdb6a6b15
+                          category:
+                            _id: 6477007a6fa4d05e1a800ce1
+                            name: Languages
+                          _id: 63ed1cd25e9d781cdb6a6b17
+                        resourceType: lesson
+                        availability:
+                          status: open
+                          date: 2022-10-18T13:25:36.292+00:00
+                createdAt: '2024-07-02T16:29:40.956Z'
+                updatedAt: '2024-09-06T15:27:29.999Z'
         400:
           description: Bad Request
           content:
@@ -300,7 +350,8 @@ paths:
           in: path
           required: true
           description: Cooperation ID
-          type: string
+          schema:
+            type: string
       requestBody:
         required: true
         description: Provide required data to update status of cooperation.

--- a/src/models/attachment.js
+++ b/src/models/attachment.js
@@ -7,7 +7,7 @@ const {
   ENUM_CAN_BE_ONE_OF
 } = require('~/consts/errors')
 const {
-  enums: { RESOURCES_TYPES_ENUM, RESOURCE_AVAILABILITY_STATUS_ENUM }
+  enums: { RESOURCES_TYPES_ENUM }
 } = require('~/consts/validation')
 
 const attachmentSchema = new Schema(
@@ -53,20 +53,6 @@ const attachmentSchema = new Schema(
     },
     isDuplicate: {
       type: Boolean
-    },
-    availability: {
-      status: {
-        type: String,
-        enum: {
-          values: RESOURCE_AVAILABILITY_STATUS_ENUM,
-          message: ENUM_CAN_BE_ONE_OF('resource availability status', RESOURCE_AVAILABILITY_STATUS_ENUM)
-        },
-        default: RESOURCE_AVAILABILITY_STATUS_ENUM[0]
-      },
-      date: {
-        type: Date,
-        default: null
-      }
     }
   },
   {

--- a/src/models/cooperation.js
+++ b/src/models/cooperation.js
@@ -9,7 +9,13 @@ const {
 } = require('~/consts/errors')
 const { USER, OFFER, COOPERATION, FINISHED_QUIZ, QUIZ } = require('~/consts/models')
 const {
-  enums: { COOPERATION_STATUS_ENUM, PROFICIENCY_LEVEL_ENUM, MAIN_ROLE_ENUM, RESOURCES_TYPES_ENUM }
+  enums: {
+    COOPERATION_STATUS_ENUM,
+    PROFICIENCY_LEVEL_ENUM,
+    MAIN_ROLE_ENUM,
+    RESOURCES_TYPES_ENUM,
+    RESOURCE_AVAILABILITY_STATUS_ENUM
+  }
 } = require('~/consts/validation')
 const { REQUESTED, UPDATED } = require('~/consts/notificationTypes')
 const notificationService = require('~/services/notification')
@@ -123,6 +129,20 @@ const cooperationSchema = new Schema(
               enum: {
                 values: RESOURCES_TYPES_ENUM,
                 message: ENUM_CAN_BE_ONE_OF('resource type', RESOURCES_TYPES_ENUM)
+              }
+            },
+            availability: {
+              status: {
+                type: String,
+                enum: {
+                  values: RESOURCE_AVAILABILITY_STATUS_ENUM,
+                  message: ENUM_CAN_BE_ONE_OF('resource availability status', RESOURCE_AVAILABILITY_STATUS_ENUM)
+                },
+                default: RESOURCE_AVAILABILITY_STATUS_ENUM[0]
+              },
+              date: {
+                type: Date,
+                default: null
               }
             }
           }

--- a/src/models/lesson.js
+++ b/src/models/lesson.js
@@ -7,7 +7,7 @@ const {
 } = require('~/consts/errors')
 const { USER, LESSON, ATTACHMENT, RESOURCES_CATEGORY } = require('~/consts/models')
 const {
-  enums: { RESOURCES_TYPES_ENUM, RESOURCE_AVAILABILITY_STATUS_ENUM }
+  enums: { RESOURCES_TYPES_ENUM }
 } = require('~/consts/validation')
 
 const lessonSchema = new Schema(
@@ -56,20 +56,6 @@ const lessonSchema = new Schema(
     },
     isDuplicate: {
       type: Boolean
-    },
-    availability: {
-      status: {
-        type: String,
-        enum: {
-          values: RESOURCE_AVAILABILITY_STATUS_ENUM,
-          message: ENUM_CAN_BE_ONE_OF('resource availability status', RESOURCE_AVAILABILITY_STATUS_ENUM)
-        },
-        default: RESOURCE_AVAILABILITY_STATUS_ENUM[0]
-      },
-      date: {
-        type: Date,
-        default: null
-      }
     }
   },
   {

--- a/src/models/quiz.js
+++ b/src/models/quiz.js
@@ -7,7 +7,7 @@ const {
   ENUM_CAN_BE_ONE_OF
 } = require('~/consts/errors')
 const {
-  enums: { QUIZ_VIEW_ENUM, RESOURCES_TYPES_ENUM, RESOURCE_AVAILABILITY_STATUS_ENUM }
+  enums: { QUIZ_VIEW_ENUM, RESOURCES_TYPES_ENUM }
 } = require('~/consts/validation')
 
 const quizSchema = new Schema(
@@ -48,20 +48,6 @@ const quizSchema = new Schema(
     },
     isDuplicate: {
       type: Boolean
-    },
-    availability: {
-      status: {
-        type: String,
-        enum: {
-          values: RESOURCE_AVAILABILITY_STATUS_ENUM,
-          message: ENUM_CAN_BE_ONE_OF('resource availability status', RESOURCE_AVAILABILITY_STATUS_ENUM)
-        },
-        default: RESOURCE_AVAILABILITY_STATUS_ENUM[0]
-      },
-      date: {
-        type: Date,
-        default: null
-      }
     },
     settings: {
       view: {

--- a/src/test/integration/controllers/attachments.spec.js
+++ b/src/test/integration/controllers/attachments.spec.js
@@ -142,10 +142,6 @@ describe('Attachments controller', () => {
             link: expect.any(String),
             size: 1524,
             category: null,
-            availability: {
-              status: 'open',
-              date: null
-            },
             resourceType: RESOURCES_TYPES_ENUM[2],
             createdAt: expect.any(String),
             updatedAt: expect.any(String)

--- a/src/test/integration/controllers/cooperation.spec.js
+++ b/src/test/integration/controllers/cooperation.spec.js
@@ -1,15 +1,21 @@
-const { serverCleanup, serverInit, stopServer } = require('~/test/setup')
-const { expectError } = require('~/test/helpers')
-const { DOCUMENT_NOT_FOUND, UNAUTHORIZED, VALIDATION_ERROR, FORBIDDEN } = require('~/consts/errors')
-const testUserAuthentication = require('~/utils/testUserAuth')
-const TokenService = require('~/services/token')
-
 const Offer = require('~/models/offer')
 const User = require('~/models/user')
 const Category = require('~/models/category')
 const Subject = require('~/models/subject')
 const Cooperation = require('~/models/cooperation')
 const Quiz = require('~/models/quiz')
+const Lesson = require('~/models/lesson')
+
+const { serverCleanup, serverInit, stopServer } = require('~/test/setup')
+const { expectError } = require('~/test/helpers')
+const { DOCUMENT_NOT_FOUND, UNAUTHORIZED, VALIDATION_ERROR, FORBIDDEN } = require('~/consts/errors')
+const testUserAuthentication = require('~/utils/testUserAuth')
+const TokenService = require('~/services/token')
+
+const { DOCUMENT_NOT_FOUND, UNAUTHORIZED, VALIDATION_ERROR, FORBIDDEN } = require('~/consts/errors')
+const {
+  enums: { RESOURCES_TYPES_ENUM }
+} = require('~/consts/validation')
 
 const endpointUrl = '/cooperations/'
 const nonExistingCooperationId = '19cf23e07281224fbbee3241'
@@ -54,8 +60,27 @@ const testCooperationData = {
   receiverRole: 'tutor',
   proficiencyLevel: 'Beginner',
   title: 'First-class teacher. Director of the Hogwarts school of magic',
-  additionalInfo:
-    'I don`t like both Dark Arts and Voldemort that`s why i want to learn your subject and became your student'
+  sections: [
+    {
+      title: 'Solving Quadratic Equations Using the Quadratic Formula',
+      description: 'Solving Quadratic Equations Using the Quadratic Formula',
+      resources: [
+        {
+          resource: {
+            _id: '6684179479e5232bce4579fa',
+            author: '6658f73f93885febb491e08b',
+            content: '<p><strong>Solving Quadratic Equations Using the Quadratic Formula</strong></p>',
+            description: 'The quadratic formula',
+            title: 'Solving Quadratic Equations Using the Quadratic Formula',
+            category: '6684175179e5232bce4579ed',
+            resourceType: RESOURCES_TYPES_ENUM[0]
+          },
+          resourceType: RESOURCES_TYPES_ENUM[0],
+          availability: { status: 'open', date: null }
+        }
+      ]
+    }
+  ]
 }
 
 const testOfferData = {
@@ -151,11 +176,8 @@ describe('Cooperation controller', () => {
 
   beforeEach(async () => {
     accessToken = await testUserAuthentication(app, studentUserData)
-
     anotherUserAccessToken = await testUserAuthentication(app, anotherUserData)
-
     testStudentUser = TokenService.validateAccessToken(accessToken)
-
     testTutorUser = await User.create(tutorUserData)
 
     const category = await Category.create({
@@ -184,6 +206,31 @@ describe('Cooperation controller', () => {
       ...testActiveQuizData
     })
 
+    const testLessonResource = await Lesson.create({
+      author: testTutorUser._id,
+      content: '<p><strong>Solving Quadratic Equations Using the Quadratic Formula</strong></p>',
+      description: 'The quadratic formula',
+      title: 'Solving Quadratic Equations Using the Quadratic Formula',
+      category: category._id,
+      resourceType: RESOURCES_TYPES_ENUM[0]
+    })
+
+    const updatedTestCooperationData = {
+      ...testCooperationData,
+      sections: [
+        {
+          ...testCooperationData.sections[0],
+          resources: [
+            {
+              resource: testLessonResource._id,
+              resourceType: RESOURCES_TYPES_ENUM[0],
+              availability: { status: 'open', date: null }
+            }
+          ]
+        }
+      ]
+    }
+
     testCooperation = await app
       .post(endpointUrl)
       .set('Cookie', [`accessToken=${accessToken}`])
@@ -191,7 +238,8 @@ describe('Cooperation controller', () => {
         receiver: testTutorUser._id,
         receiverRole: tutorUserData.role[0],
         offer: testOffer._id,
-        ...testCooperationData
+        sections: updatedTestCooperationData.sections,
+        ...updatedTestCooperationData
       })
   })
 
@@ -226,7 +274,6 @@ describe('Cooperation controller', () => {
         },
         initiator: testStudentUser.id,
         receiver: testTutorUser._id,
-        additionalInfo: testCooperationData.additionalInfo,
         proficiencyLevel: testCooperationData.proficiencyLevel,
         price: testCooperationData.price,
         title: testCooperationData.title,
@@ -266,12 +313,36 @@ describe('Cooperation controller', () => {
         },
         receiver: testTutorUser._id,
         receiverRole: tutorUserData.role[0],
-        additionalInfo: testCooperationData.additionalInfo,
         proficiencyLevel: testCooperationData.proficiencyLevel,
         price: testCooperationData.price,
         title: testCooperationData.title,
         status: 'pending',
         needAction: tutorUserData.role[0],
+        sections: [
+          {
+            _id: expect.any(String),
+            title: testCooperationData.sections[0].title,
+            description: testCooperationData.sections[0].description,
+            resources: [
+              {
+                resource: expect.objectContaining({
+                  _id: expect.any(String),
+                  author: expect.any(String),
+                  content: expect.any(String),
+                  description: expect.any(String),
+                  title: expect.any(String),
+                  category: expect.any(String),
+                  resourceType: expect.any(String)
+                }),
+                resourceType: testCooperationData.sections[0].resources[0].resourceType,
+                availability: {
+                  status: testCooperationData.sections[0].resources[0].availability.status,
+                  date: testCooperationData.sections[0].resources[0].availability.date
+                }
+              }
+            ]
+          }
+        ],
         createdAt: testCooperation._body.createdAt,
         updatedAt: testCooperation._body.updatedAt
       })
@@ -301,12 +372,21 @@ describe('Cooperation controller', () => {
         initiator: testStudentUser.id,
         receiver: testTutorUser._id,
         receiverRole: tutorUserData.role[0],
-        additionalInfo: testCooperationData.additionalInfo,
         proficiencyLevel: testCooperationData.proficiencyLevel,
         price: testCooperationData.price,
         title: testCooperationData.title,
         status: 'pending',
         needAction: tutorUserData.role[0],
+        sections: testCooperationData.sections.map((section) => ({
+          _id: expect.any(String),
+          title: section.title,
+          description: section.description,
+          resources: section.resources.map((resource) => ({
+            resource: expect.any(String),
+            resourceType: resource.resourceType,
+            availability: resource.availability
+          }))
+        })),
         createdAt: testCooperation._body.createdAt,
         updatedAt: testCooperation._body.updatedAt
       })

--- a/src/test/integration/controllers/cooperation.spec.js
+++ b/src/test/integration/controllers/cooperation.spec.js
@@ -8,7 +8,6 @@ const Lesson = require('~/models/lesson')
 
 const { serverCleanup, serverInit, stopServer } = require('~/test/setup')
 const { expectError } = require('~/test/helpers')
-const { DOCUMENT_NOT_FOUND, UNAUTHORIZED, VALIDATION_ERROR, FORBIDDEN } = require('~/consts/errors')
 const testUserAuthentication = require('~/utils/testUserAuth')
 const TokenService = require('~/services/token')
 

--- a/src/test/integration/controllers/course.spec.js
+++ b/src/test/integration/controllers/course.spec.js
@@ -1,18 +1,21 @@
+const Course = require('~/models/course')
+
+const uploadService = require('~/services/upload')
+const { expectError } = require('~/test/helpers')
 const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
 const checkCategoryExistence = require('~/seed/checkCategoryExistence')
 const testUserAuthentication = require('~/utils/testUserAuth')
-const Course = require('~/models/course')
-const { expectError } = require('~/test/helpers')
+
 const { UNAUTHORIZED, DOCUMENT_NOT_FOUND, FORBIDDEN } = require('~/consts/errors')
-const uploadService = require('~/services/upload')
 const {
   roles: { STUDENT, TUTOR }
 } = require('~/consts/auth')
+const {
+  enums: { RESOURCES_TYPES_ENUM }
+} = require('~/consts/validation')
 
 const endpointUrl = '/courses/'
-
 const mockUploadFile = jest.fn().mockResolvedValue('mocked-file-url')
-
 const nonExistingCourseId = '64a51e41de4debbccf0b39b0'
 
 const tutorUser = {
@@ -58,9 +61,9 @@ const testCourseData = {
             description: 'some text',
             content:
               '<div>\n<div>Lorem ipsum dolor sit, amet consectetur am quos dolorum at voluptates obcaecati.</div>\n</div>',
-            resourceType: 'lesson'
+            resourceType: RESOURCES_TYPES_ENUM[0]
           },
-          resourceType: 'lesson',
+          resourceType: RESOURCES_TYPES_ENUM[0],
           isDuplicate: true
         }
       ]

--- a/src/test/integration/controllers/lesson.spec.js
+++ b/src/test/integration/controllers/lesson.spec.js
@@ -12,10 +12,6 @@ const testLesson = {
   description: 'description',
   category: '6502ec2060ec37be943353e2',
   content: '<h1>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</h1>',
-  availability: {
-    status: 'open',
-    date: null
-  },
   attachments: ['65bed8ef260f18d04ab22da3', '65bed9ef260f19d05ab25bc6']
 }
 

--- a/src/test/integration/controllers/quiz.spec.js
+++ b/src/test/integration/controllers/quiz.spec.js
@@ -17,10 +17,6 @@ const testQuizData = {
   title: 'Assembly',
   description: 'Description',
   resourceType: RESOURCES_TYPES_ENUM[1],
-  availability: {
-    status: 'open',
-    date: null
-  },
   settings: {
     correctAnswers: false,
     pointValues: false,


### PR DESCRIPTION
## Removed the "`availability`" field from the `Lesson`, `Quiz`, and `Attachment` entities [ Close #903 ]

The field `availability` removed from the `Lesson`, `Quiz`, and `Attachment` entities. This is because resources are added as links within the `Cooperation` entity, and the `availability` of these resources should be set at the `Cooperation` level. Having `availability` at the entity level would be redundant and inconsistent, as it could change independently for resources added as links:

<img width="1732" alt="Screenshot 2024-09-06 at 23 02 00" src="https://github.com/user-attachments/assets/3926b318-f30f-4b7c-a30f-5ac561735229">

<img width="1547" alt="Screenshot 2024-09-06 at 23 20 26" src="https://github.com/user-attachments/assets/45fa3207-8de8-4a64-820e-7dd28cdf16b9">

# 

### After changes:
| Creating a New Lesson:                                                                                      |
|-------------------------------------------------------------------------------------------------------------|
| <img width="1336" alt="Screenshot 2024-09-06 at 22 32 10" src="https://github.com/user-attachments/assets/112cfe70-8c83-4920-934a-08424c16cc1b"> |
| Saved lesson in `Lessons` entity without field `availability`:                                                   |
| <img width="735" alt="Screenshot 2024-09-06 at 22 33 00" src="https://github.com/user-attachments/assets/1d0e25db-e0b8-4b16-8cc1-a82a328fc1cb">   |


| Creating a New Quiz:                                                                                      |
|-------------------------------------------------------------------------------------------------------------|
| <img width="1619" alt="Screenshot 2024-09-06 at 22 39 45" src="https://github.com/user-attachments/assets/89466c22-79ef-49db-a3e0-c9f03d40917d"> |
| Saved quiz in `Quizzes` entity without field `availability`:                                                   |
| <img width="735" alt="Screenshot 2024-09-06 at 22 41 02" src="https://github.com/user-attachments/assets/be6d751b-e527-4248-9018-baf4aabb7bc0">   |