### PR TITLE
Fixed swagger docs for PATCH /auth/change-password/{id}

### DIFF
--- a/docs/auth/auth-schema.yaml
+++ b/docs/auth/auth-schema.yaml
@@ -42,3 +42,10 @@ definitions:
     properties:
       password:
         type: string
+  change-password:
+    type: object
+    properties:
+      currentPassword:
+        type: string
+      password:
+        type: string


### PR DESCRIPTION
- [x] added the `change-password` type to definitions in swagger docs to fix the error