### PR TITLE
Fixed swagger docs for Resources Categories endpoints

### DIFF
--- a/docs/resourcesCategory/resourcesCategory.schema.yaml
+++ b/docs/resourcesCategory/resourcesCategory.schema.yaml
@@ -2,7 +2,8 @@ definitions:
   resourceCategoryBody:
     type: object
     properties:
-      name: string
+      name:
+        type: string
   resourcesCategory:
     type: object
     properties:
@@ -12,7 +13,6 @@ definitions:
         type: string
       author:
         type: string
-        ref: '#/components/user'
       createdAt:
         type: string
         format: date-time

--- a/docs/resourcesCategory/resourcesCategory.yaml
+++ b/docs/resourcesCategory/resourcesCategory.yaml
@@ -79,7 +79,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/resourcesCategoryBody'
+              $ref: '#/definitions/resourceCategoryBody'
             example:
               name: Chemical Category
       responses:
@@ -88,7 +88,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/resources-categories'
+                $ref: '#/definitions/resourcesCategory'
               example:
                 _id: 650b14441e8d4a4484e2e2f5
                 name: Chemical Category
@@ -216,7 +216,7 @@ paths:
       security:
         - cookieAuth: []
       tags:
-        - ResourcesCategories
+        - Resources Categories
       summary: Delete ResourcesCategory by ID
       description: Finds and deletes an ResourcesCategory with the specified ID.
       produces:


### PR DESCRIPTION
- [x] fixed errors in swagger docs for the POST /resources-categories endpoint
- [x] grouped all resources categories endpoints together

Before:
<img width="1420" alt="Screenshot 2024-09-15 at 15 21 18" src="https://github.com/user-attachments/assets/47fd4c8e-2b1f-4fe0-9c03-e82a478302cd">
After:
<img width="602" alt="Screenshot 2024-09-15 at 15 49 43" src="https://github.com/user-attachments/assets/4425243f-8f8e-4097-8baf-87e5155b53f2">
