### PR TITLE
Implemented sending token via cookie for auth in the socket server

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "azure-storage": "^2.10.7",
     "bcrypt": "^5.0.1",
+    "cookie": "^0.6.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "cron": "^2.1.0",

--- a/src/initialization/socketServerSetup.js
+++ b/src/initialization/socketServerSetup.js
@@ -1,10 +1,14 @@
 const { createServer } = require('http')
 const { Server } = require('socket.io')
-const { authSocketMiddleware } = require('~/middlewares/auth')
-const registerActivityHandlers = require('~/event-handlers/activityHandler')
 const {
   config: { CLIENT_URL }
 } = require('~/configs/config')
+const {
+  config: { COOKIE_DOMAIN }
+} = require('~/configs/config')
+const { oneDayInMs } = require('~/consts/auth')
+const { authSocketMiddleware } = require('~/middlewares/auth')
+const registerActivityHandlers = require('~/event-handlers/activityHandler')
 
 let usersOnline = new Set()
 
@@ -17,7 +21,13 @@ const socketServerSetup = (app) => {
       methods: 'GET, POST, PATCH, DELETE',
       allowedHeaders: 'Content-Type, Authorization'
     },
-    cookie: true
+    cookie: {
+      maxAge: oneDayInMs,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+      domain: COOKIE_DOMAIN
+    }
   })
 
   io.use(authSocketMiddleware)

--- a/src/initialization/socketServerSetup.js
+++ b/src/initialization/socketServerSetup.js
@@ -16,7 +16,8 @@ const socketServerSetup = (app) => {
       credentials: true,
       methods: 'GET, POST, PATCH, DELETE',
       allowedHeaders: 'Content-Type, Authorization'
-    }
+    },
+    cookie: true
   })
 
   io.use(authSocketMiddleware)

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -23,7 +23,7 @@ const authSocketMiddleware = (socket, next) => {
     return next(createUnauthorizedError())
   }
 
-  const { accessToken } = cookie.parse(socket.request.headers?.cookie)
+  const { accessToken } = cookie.parse(socket.request.headers.cookie)
 
   if (!accessToken) {
     return next(createUnauthorizedError())

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,3 +1,4 @@
+const cookie = require('cookie')
 const { createUnauthorizedError, createForbiddenError } = require('~/utils/errorsHelper')
 const tokenService = require('~/services/token')
 
@@ -18,15 +19,19 @@ const authMiddleware = (req, _res, next) => {
 }
 
 const authSocketMiddleware = (socket, next) => {
-  const accessToken = socket.handshake.auth?.token
+  if (!socket.request.headers.cookie) {
+    return next(createUnauthorizedError())
+  }
+
+  const { accessToken } = cookie.parse(socket.request.headers?.cookie)
 
   if (!accessToken) {
-    next(createUnauthorizedError())
+    return next(createUnauthorizedError())
   }
 
   const userData = tokenService.validateAccessToken(accessToken)
   if (!userData) {
-    next(createUnauthorizedError())
+    return next(createUnauthorizedError())
   }
 
   socket.user = userData

--- a/src/test/unit/middlewares/authSocket.spec.js
+++ b/src/test/unit/middlewares/authSocket.spec.js
@@ -7,16 +7,16 @@ describe('Auth socket midleware', () => {
   const error = createUnauthorizedError()
   const mockNextFunc = jest.fn()
 
-  it('Should call next function with UNAUTHORIZED error when access token is not given', () => {
-    const mockSocket = { handshake: { auth: {} } }
+  it('Should call the next function with UNAUTHORIZED error when cookies are not given', () => {
+    const mockSocket = { request: { headers: {} } }
 
     authSocketMiddleware(mockSocket, mockNextFunc)
 
     expect(mockNextFunc).toHaveBeenCalledWith(error)
   })
 
-  it('Should call next function with UNAUTHORIZED error when access token is not given', () => {
-    const mockSocket = { handshake: { auth: { token: 'invalid_token' } } }
+  it('Should call the next function with UNAUTHORIZED error when access token is not given', () => {
+    const mockSocket = { request: { headers: { cookie: '' } } }
 
     authSocketMiddleware(mockSocket, mockNextFunc)
 
@@ -26,7 +26,7 @@ describe('Auth socket midleware', () => {
   it('Should save userData from accessToken to a socket object', () => {
     const payload = { userId: 'testId' }
     const { accessToken } = tokenService.generateTokens(payload)
-    const mockSocket = { handshake: { auth: { token: accessToken } } }
+    const mockSocket = { request: { headers: { cookie: `accessToken=${accessToken};` } } }
 
     authSocketMiddleware(mockSocket, mockNextFunc)
 

--- a/src/test/unit/middlewares/authSocket.spec.js
+++ b/src/test/unit/middlewares/authSocket.spec.js
@@ -7,6 +7,10 @@ describe('Auth socket midleware', () => {
   const error = createUnauthorizedError()
   const mockNextFunc = jest.fn()
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('Should call the next function with UNAUTHORIZED error when cookies are not given', () => {
     const mockSocket = { request: { headers: {} } }
 
@@ -17,6 +21,22 @@ describe('Auth socket midleware', () => {
 
   it('Should call the next function with UNAUTHORIZED error when access token is not given', () => {
     const mockSocket = { request: { headers: { cookie: '' } } }
+
+    authSocketMiddleware(mockSocket, mockNextFunc)
+
+    expect(mockNextFunc).toHaveBeenCalledWith(error)
+  })
+
+  it('Should call the next function with UNAUTHORIZED error when access token is empty', () => {
+    const mockSocket = { request: { headers: { cookie: 'accessToken=;' } } }
+
+    authSocketMiddleware(mockSocket, mockNextFunc)
+
+    expect(mockNextFunc).toHaveBeenCalledWith(error)
+  })
+
+  it('Should call the nest function with UNAUTHORIZED error when access token is invalid', () => {
+    const mockSocket = { request: { headers: { cookie: 'accessToken=invalid_token;' } } }
 
     authSocketMiddleware(mockSocket, mockNextFunc)
 

--- a/src/test/unit/middlewares/authSocket.spec.js
+++ b/src/test/unit/middlewares/authSocket.spec.js
@@ -35,7 +35,7 @@ describe('Auth socket midleware', () => {
     expect(mockNextFunc).toHaveBeenCalledWith(error)
   })
 
-  it('Should call the nest function with UNAUTHORIZED error when access token is invalid', () => {
+  it('Should call the next function with UNAUTHORIZED error when access token is invalid', () => {
     const mockSocket = { request: { headers: { cookie: 'accessToken=invalid_token;' } } }
 
     authSocketMiddleware(mockSocket, mockNextFunc)


### PR DESCRIPTION
## Done
Implemented sending accessToken via cookie instead of auth payload to authenticate in the socket server. It improved security and made connection from the frontend more convenient.