### PR TITLE
Copied fields from offers to cooperations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-report.xml
 
 # sonar scanner work
 .scannerwork
+debug.json
 
 # misc
 .DS_Store

--- a/docs/cooperation/cooperation.schema.yaml
+++ b/docs/cooperation/cooperation.schema.yaml
@@ -6,8 +6,48 @@ definitions:
       properties:
         _id:
           type: string
+        proficiencyLevel:
+          type: array
+          $ref: '#/definitions/proficiencyLevelEnum'
+          items:
+            type: string
+        subject:
+          type: object
+          properties:
+            name:
+              type: string
+        category:
+          type: object
+          properties:
+            appearance:
+              type: object
+              properties:
+                color:
+                  type: string
+                icon:
+                  type: string
+        user:
+          type: object
+          $ref: '#/definitions/userInCooperations'
+          properties:
+            _id:
+              type: string
+            firstName:
+              type: string
+            lastName:
+              type: string
+            photo:
+              type: string
+            role:
+              type: string
+        description:
+          type: string
+        languages:
+          type: array
+          items:
+            type: string
         offer:
-          $ref: '#/definitions/offerInCooperations'
+          type: string
         initiator:
           type: string
         initiatorRole:
@@ -20,8 +60,6 @@ definitions:
           type: string
         additionalInfo:
           type: string
-        proficiencyLevel:
-          $ref: '#/definitions/proficiencyLevelEnum'
         price:
           type: number
         status:
@@ -42,47 +80,204 @@ definitions:
         updatedAt:
           type: string
           format: date-time
-        user:
-          $ref: '#/definitions/userInCooperations'
   cooperation:
     type: object
     properties:
       _id:
         type: string
       offer:
-        $ref: '#/definitions/offerInCooperationExtended'
+        type: string
+        ref: '#components/offer'
       initiator:
-        $ref: '#/definitions/userInCooperationsExtended'
+        type: string
+        ref: '#/components/user'
       initiatorRole:
-        $ref: '#/definitions/baseUserRoleEnum'
+        type: string
       receiver:
-        $ref: '#/definitions/userInCooperationsExtended'
+        type: string
+        ref: '#components/user'
       receiverRole:
         $ref: '#/definitions/baseUserRoleEnum'
       title:
         type: string
-      additionalInfo:
-        type: string
-      proficiencyLevel:
-        $ref: '#/definitions/proficiencyLevelEnum'
-      price:
-        type: number
       status:
-        $ref: '#/definitions/cooperationStatusEnum'
-      needAction:
-        $ref: '#/definitions/baseUserRoleEnum'
-      availableQuizzes:
-        type: array
-        items:
-          type: string
-      finishedQuizzes:
-        type: array
-        items:
-          type: string
+        type: string
+        enum:
+          - pending
+          - active
+          - declined
+          - closed
       sections:
         type: array
         items:
-          $ref: '#/definitions/section'
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            resources:
+              type: array
+              items:
+                type: object
+                properties:
+                  resource:
+                    type: object
+                    additionalProperties: true
+                  resourceType:
+                    type: string
+                    enum:
+                      - lesson
+                      - quiz
+                      - attachment
+                  availability:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - open
+                          - closed
+                          - openFrom
+                        default: open
+                      date:
+                        type: string
+                        format: date-time
+                        default: null
+      needAction:
+        type: string
+        enum:
+          - student
+          - tutor
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
+  cooperationResponse:
+    type: object
+    properties:
+      _id:
+        type: string
+      offer:
+        type: object
+        properties:
+          _id:
+            type: string
+          author:
+            type: object
+            properties:
+              _id:
+                type: string
+              averageRating:
+                type: object
+                properties:
+                  student:
+                    type: number
+                  tutor:
+                    type: number
+              firstName:
+                type: string
+              lastName:
+                type: string
+              photo:
+                type: string
+              professionalSummary:
+                type: string
+              totalReviews:
+                type: object
+                properties:
+                  student:
+                    type: number
+                  tutor:
+                    type: number
+      initiator:
+        type: string
+      initiatorRole:
+        type: string
+      proficiencyLevel:
+        type: array
+        items:
+          type: string
+      subject:
+        type: object
+        properties:
+          name:
+            type: string
+      category:
+        type: object
+        properties:
+          appearance:
+            type: object
+            properties:
+              color:
+                type: string
+              icon:
+                type: string
+      description:
+        type: string
+      languages:
+        type: array
+        items:
+          type: string
+      receiver:
+        type: string
+      receiverRole:
+        type: string
+      price:
+        type: number
+      title:
+        type: string
+      status:
+        type: string
+        enum:
+          - pending
+          - active
+          - declined
+          - closed
+      sections:
+        type: array
+        items:
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            resources:
+              type: array
+              items:
+                type: object
+                properties:
+                  resource:
+                    type: object
+                    additionalProperties: true
+                  resourceType:
+                    type: string
+                    enum:
+                      - lesson
+                      - quiz
+                      - attachment
+                  availability:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - open
+                          - closed
+                          - openFrom
+                        default: open
+                      date:
+                        type: string
+                        format: date-time
+                        default: null
+      needAction:
+        type: string
+        enum:
+          - student
+          - tutor
       createdAt:
         type: string
         format: date-time

--- a/docs/cooperation/cooperation.yaml
+++ b/docs/cooperation/cooperation.yaml
@@ -17,73 +17,62 @@ paths:
               schema:
                 $ref: '#/definitions/cooperations'
               example:
-                count: 2
-                items:
-                  - _id: 63ebc6fbd2f34037d0aba314
-                    offer:
-                      _id: 6741b51f1550cb6f3fae7a6c
-                      price: 500
-                      title: Advanced English Course
-                      subject:
-                        _id: 6675874d59019cd05eb11a14
-                        name: English
-                      category:
-                        _id: 64884f4dfdc2d1a130c24ac6
-                        appearance:
-                          icon: mocked-path-to-icon
-                          color: '#F67C41'
-                    initiator: 6255bc080a75adf9223df212
-                    initiatorRole: tutor
-                    receiver: 6255bc080a75adf9223df100
-                    receiverRole: student
-                    title: Advanced English Course
-                    additionalInfo: The Advanced English Course is designed for individuals who already have a strong grasp of English and wish to refine their skills to reach professional or near-native proficiency. This course focuses on advanced grammar, vocabulary, nuanced language use, and cultural fluency.
-                    proficiencyLevel: Advanced
-                    price: 500
-                    status: active
-                    needAction: student
-                    availableQuizzes: []
-                    finishedQuizzes: []
-                    createdAt: 2021-05-09T11:34:53.243+00:00
-                    updatedAt: 2022-07-02T11:59:53.243+00:00
-                    user:
-                      _id: 6255bc080a75adf9223df100
-                      firstName: Emily
-                      lastName: Jonson
-                      photo: ''
-                      role: student
-                  - _id: 63ebc6fbd2f34037d0aba315
-                    offer:
-                      _id: 6741b51f1550cb6f3fae7a6d
-                      price: 800
-                      title: 'Biochemistry: Enzymes and Their Functions'
-                      subject:
-                        _id: 6675874d59019cd05eb11a54
-                        name: Biochemistry
-                      category:
-                        _id: 64884f4dfdc2d1a130c24ac6
-                        appearance:
-                          icon: mocked-path-to-icon
-                          color: '#F67C42'
-                    initiator: 6255bc080a75adf9223df213
-                    initiatorRole: tutor
-                    receiver: 6255bc080a75adf9223df103
-                    receiverRole: student
-                    title: 'Biochemistry: Enzymes and Their Functions'
-                    additionalInfo: This course explores the world of enzymes, the catalysts of life. It includes enzyme classification, mechanisms of action, kinetics, regulation, and real-world applications in medicine and biotechnology. Perfect for students aiming to deepen their understanding of biochemical processes.
-                    price: 800
-                    status: active
-                    needAction: student
-                    availableQuizzes: []
-                    finishedQuizzes: []
-                    createdAt: 2021-06-12T11:34:53.243+00:00
-                    updatedAt: 2022-06-13T11:59:53.243+00:00
-                    user:
-                      _id: 6255bc080a75adf9223df154
-                      firstName: Liam
-                      lastName: Brown
-                      photo: ''
-                      role: student
+                - _id: 63ebc6fbd2f34037d0aba314
+                  offer: 63ebc6fbd2f34037d0aba791
+                  initiator: 6255bc080a75adf9223df212
+                  initiatorRole: tutor
+                  receiver: 6255bc080a75adf9223df100
+                  receiverRole: student
+                  title: 'Violin lessons'
+                  proficiencyLevel: ['Intermediate']
+                  subject: { name: 'Music' }
+                  category: { appearance: { color: '#E3B21C', icon: 'ScienceRoundedIcon' } }
+                  user:
+                    {
+                      _id: '66b0aecdadd1fe775238c7d5',
+                      firstName: 'Pavlo',
+                      lastName: 'Dolia',
+                      photo: '1726302778023-pexels-olly-3769706.jpg',
+                      role: 'student'
+                    }
+                  description: "I'll teach you how to play violin"
+                  languages: ['English']
+                  price: 200
+                  status: active
+                  needAction: student
+                  availableQuizzes: []
+                  finishedQuizzes: []
+                  sections: []
+                  createdAt: 2021-05-09T11:34:53.243+00:00
+                  updatedAt: 2022-07-02T11:59:53.243+00:00
+                - _id: 63ebc6fbd2f34037d0aba314
+                  offer: 63ebc6fbd2f34037d0aba791
+                  initiator: 6255bc080a75adf9223df212
+                  initiatorRole: tutor
+                  receiver: 6255bc080a75adf9223df100
+                  receiverRole: student
+                  title: 'Violin lessons'
+                  proficiencyLevel: ['Intermediate']
+                  subject: { name: 'Music' }
+                  category: { appearance: { color: '#E3B21C', icon: 'ScienceRoundedIcon' } }
+                  user:
+                    {
+                      _id: '66b0aecdadd1fe775238c7d5',
+                      firstName: 'Pavlo',
+                      lastName: 'Dolia',
+                      photo: '1726302778023-pexels-olly-3769706.jpg',
+                      role: 'student'
+                    }
+                  description: "I'll teach you how to play violin"
+                  languages: ['English']
+                  price: 300
+                  status: closed
+                  needAction: tutor
+                  availableQuizzes: []
+                  finishedQuizzes: []
+                  sections: []
+                  createdAt: 2021-04-09T11:34:53.243+00:00
+                  updatedAt: 2022-09-02T11:59:53.243+00:00
         401:
           description: Unauthorized
           content:
@@ -112,11 +101,18 @@ paths:
               $ref: '#/definitions/cooperationBody'
             example:
               title: Violin lessons
-              proficiencyLevel: Test Preparation
               offer: 63ebc6fbd2f34037d0aba791
+              initiator: 6255bc080a75adf9223df212
+              initiatorRole: tutor
               receiver: 6255bc080a75adf9223df100
               receiverRole: student
+              proficiencyLevel: ['Intermediate']
               price: 300
+              needAction: tutor
+              subject: 6255bc080a75adf9223df103
+              category: 6255bc080a75adf9223df104
+              description: "I'll teach you how to play violin"
+              languages: ['English']
       responses:
         201:
           description: Created
@@ -126,13 +122,21 @@ paths:
                 $ref: '#/definitions/cooperation'
               example:
                 _id: 8755bc080a00adr9243df104
-                offer: 63ebc6fbd2f34037d0aba791
+                offer:
+                  {
+                    _id: '66ec53d40d9d9983a9525421',
+                    price: 400,
+                    title: 'Violin lessons',
+                    subject: { _id: '656605be8bebd72f0be56a3d', name: 'Violin' },
+                    category:
+                      { appearance: { icon: 'StarRoundedIcon', color: '#607D8B' }, _id: '6566040f8bebd72f0be55a28' }
+                  }
                 initiator: 6255bc080a75adf9223df212
                 initiatorRole: tutor
                 receiver: 6255bc080a75adf9223df100
                 receiverRole: student
-                title: Violin lessons
-                proficiencyLevel: Intermediate
+                title: 'Violin lessons'
+                proficiencyLevel: ['Intermediate']
                 price: 300
                 status: pending
                 needAction: student
@@ -141,6 +145,18 @@ paths:
                 sections: []
                 createdAt: 2021-04-09T11:34:53.243+00:00
                 updatedAt: 2022-09-02T11:59:53.243+00:00
+                category: '6566040f8bebd72f0be55a28'
+                description: "I'll teach you how to play violin"
+                languages: ['English']
+                subject: { _id: '656605be8bebd72f0be56a3d', name: 'Violin' }
+                user:
+                  {
+                    _id: '66b0aecdadd1fe775238c7d5',
+                    firstName: 'John',
+                    lastName: 'Doe',
+                    photo: '1726302778023-pexels-olly-3769706.jpg',
+                    role: 'student'
+                  }
         400:
           description: Bad Request
           content:
@@ -184,356 +200,151 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/cooperation'
-              examples:
-                studentView:
-                  summary: Student view
-                  value:
-                    _id: 8755bc080a00adr9243df106
-                    offer:
-                      _id: 63ebc6fbd2f34037d0aba791
-                      proficiencyLevel:
-                        - Intermediate
-                        - Advanced
-                        - Test Preparation
-                        - Professional
-                      title: Understanding Quadratic Equations
-                      description: In this lesson, we will delve into the world of quadratic equations. We'll explore the standard form of a quadratic equation, learn how to identify the coefficients, and understand the significance of the discriminant. Students will also practice solving quadratic equations using various methods, including factoring, completing the square, and the quadratic formula. By the end of the lesson, students will be able to solve quadratic equations confidently and understand their graphical representations.
-                      languages:
-                        - English
-                      author:
-                        totalReviews:
-                          student: 0
-                          tutor: 0
-                        averageRating:
-                          student: 0
-                          tutor: 0
-                        _id: 6658f73f93885febb491e08b
-                        firstName: John
-                        lastName: Doe
-                        photo: 6658f73f93885-test_student.png
-                        professionalSummary: I am student of the University of Cambridge. I am passionate about learning mathematics.
-                      subject:
-                        _id: 6566133a2bccdd3e18dbe943
-                        name: Algebra
-                      category:
-                        appearance:
-                          color: '#E3B21C'
-                          icon: TagRoundedIcon
-                        _id: 64884f33fdc2d1a130c24ac2
-                        name: Mathematics
-                    initiator:
-                      address:
-                        country: USA
-                        city: California
-                      mainSubjects:
-                        student: []
-                        tutor: []
-                      totalReviews:
-                        student: 8
-                        tutor: 7.5
-                      averageRating:
-                        student: 5
-                        tutor: 4.9
-                      status:
-                        student: active
-                        tutor: active
-                        admin: active
-                      videoLink:
-                        student: https://www.youtube.com/watch?v=ebTnuLRnIOY-JohnDoe
-                      professionalBlock:
-                        awards: Gold medal in mathematics competition
-                        scientificActivities: Founded the Math Club at the University of Cambridge
-                        workExperience: n/a
-                        education: Working towards a Bachelor of Mathematics at the University of Cambridge
-                      notificationSettings:
-                        isOfferStatusNotification: true
-                        isChatNotification: true
-                        isSimilarOffersNotification: true
-                        isEmailNotification: true
-                      _id: 6658f6b793885febb491e07c
-                      role:
-                        - student
-                      firstName: John
-                      lastName: Doe
-                      email: john_doe@gmail.com
-                      nativeLanguage: English
-                      lastLogin: 2024-08-06T13:47:50.872Z
-                      createdAt: 2024-05-30T21:59:19.434Z
-                      updatedAt: 2024-08-06T13:47:50.872Z
-                      professionalSummary: I am a student at the University of Cambridge studying Mathematics. I am passionate about learning mathematics.
-                    initiatorRole: student
-                    receiver:
-                      address:
-                        country: USA
-                        city: Massachusetts
-                      mainSubjects:
-                        student: []
-                        tutor:
-                          - category: 64884f4dfdc2d1a130c24ac6
-                            subjects:
-                              - 6675874d59019cd05eb11a16
-                              - 65660fbbcb972798c401a9b4
-                            _id: 6675a09d83835d79e960087a
-                          - category: 64884f98fdc2d1a130c24ad4
-                            subjects:
-                              - 66758d6e59019cd05eb11a5d
-                            _id: 6675a08e83835d79e9600842
-                          - category: 64884f33fdc2d1a130c24ac2
-                            subjects:
-                              - 6566133a2bccdd3e18dbe943
-                            _id: 6675a06f83835d79e96007fc
-                      totalReviews:
-                        student: 10
-                        tutor: 8
-                      averageRating:
-                        student: 4.5
-                        tutor: 4.9
-                      status:
-                        student: active
-                        tutor: active
-                        admin: active
-                      videoLink:
-                        tutor: https://www.youtube.com/watch?v=ebTnuLRnIOY-JaneRoe
-                      professionalBlock:
-                        awards: The best tutor of the year 2023
-                        scientificActivities: The author of the scientific work 'The role of mathematics in the development of society'
-                        workExperience: I have been tutoring students in Mathematics for over 5 years and have helped many students achieve their academic goals.
-                        education: The University of Cambridge, Bachelor of Mathematics
-                      notificationSettings:
-                        isOfferStatusNotification: true
-                        isChatNotification: true
-                        isSimilarOffersNotification: true
-                        isEmailNotification: true
-                      _id: 6658f73f93885febb491e08b
-                      role:
-                        - tutor
-                      firstName: Jane
-                      lastName: Roe
-                      email: jane_roe@gmail.com
-                      nativeLanguage: null
-                      lastLogin: 2024-09-06T21:08:58.254Z
-                      createdAt: 2024-05-30T22:01:35.360Z
-                      updatedAt: 2024-09-06T21:08:58.256Z
-                      photo: 6658f73f938-test_tutor.png
-                      professionalSummary: Recently graduated from the University of Cambridge with a degree in Mathematics. I have been tutoring students in Mathematics for over 5 years and have helped many students achieve their academic goals. I am passionate about teaching and enjoy helping students understand complex mathematical concepts. I believe that every student has the potential to succeed and I am committed to helping them reach their full potential.
-                    receiverRole: tutor
-                    title: Understanding Quadratic Equations
-                    proficiencyLevel: Intermediate
-                    price: 150
-                    status: active
-                    needAction: tutor
-                    availableQuizzes: []
-                    finishedQuizzes: []
-                    sections:
-                      - title: Section title
-                        description: Section description
-                        resources:
-                          - resource:
-                              title: Colors in English
-                              description: With this lesson you will learn all about colors in English.
-                              content: <h1>Title</h1>
-                              author: 63da8767c9ad4c9a0b0eacd3
-                              attachments:
-                                - 63ed1cd25e9d781cdb6a6b15
-                              category:
-                                _id: 6477007a6fa4d05e1a800ce1
-                                name: Languages
-                              _id: 63ed1cd25e9d781cdb6a6b17
-                            resourceType: lesson
-                            availability:
-                              status: open
-                              date: null
-                        _id: 674cae6458b8af8857ffac8a
-                    createdAt: '2024-07-02T16:29:40.956Z'
-                    updatedAt: '2024-09-06T15:27:29.999Z'
-                tutorView:
-                  summary: Tutor view
-                  value:
-                    _id: 8755bc080a00adr9243df106
-                    offer:
-                      _id: 63ebc6fbd2f34037d0aba791
-                      proficiencyLevel:
-                        - Intermediate
-                        - Advanced
-                        - Test Preparation
-                        - Professional
-                      title: Understanding Quadratic Equations
-                      description: In this lesson, we will delve into the world of quadratic equations. We'll explore the standard form of a quadratic equation, learn how to identify the coefficients, and understand the significance of the discriminant. Students will also practice solving quadratic equations using various methods, including factoring, completing the square, and the quadratic formula. By the end of the lesson, students will be able to solve quadratic equations confidently and understand their graphical representations.
-                      languages:
-                        - English
-                      author:
-                        totalReviews:
-                          student: 0
-                          tutor: 0
-                        averageRating:
-                          student: 0
-                          tutor: 0
-                        _id: 6658f73f93885febb491e08b
-                        firstName: John
-                        lastName: Doe
-                        photo: 6658f73f93885-test_student.png
-                        professionalSummary: I am student of the University of Cambridge. I am passionate about learning mathematics.
-                      subject:
-                        _id: 6566133a2bccdd3e18dbe943
-                        name: Algebra
-                      category:
-                        appearance:
-                          color: '#E3B21C'
-                          icon: TagRoundedIcon
-                        _id: 64884f33fdc2d1a130c24ac2
-                        name: Mathematics
-                    initiator:
-                      address:
-                        country: USA
-                        city: California
-                      mainSubjects:
-                        student: []
-                        tutor: []
-                      totalReviews:
-                        student: 8
-                        tutor: 7.5
-                      averageRating:
-                        student: 5
-                        tutor: 4.9
-                      status:
-                        student: active
-                        tutor: active
-                        admin: active
-                      videoLink:
-                        student: https://www.youtube.com/watch?v=ebTnuLRnIOY-JohnDoe
-                      professionalBlock:
-                        awards: Gold medal in mathematics competition
-                        scientificActivities: Founded the Math Club at the University of Cambridge
-                        workExperience: n/a
-                        education: Working towards a Bachelor of Mathematics at the University of Cambridge
-                      notificationSettings:
-                        isOfferStatusNotification: true
-                        isChatNotification: true
-                        isSimilarOffersNotification: true
-                        isEmailNotification: true
-                      _id: 6658f6b793885febb491e07c
-                      role:
-                        - student
-                      firstName: John
-                      lastName: Doe
-                      email: john_doe@gmail.com
-                      nativeLanguage: English
-                      lastLogin: 2024-08-06T13:47:50.872Z
-                      createdAt: 2024-05-30T21:59:19.434Z
-                      updatedAt: 2024-08-06T13:47:50.872Z
-                      professionalSummary: I am a student at the University of Cambridge studying Mathematics. I am passionate about learning mathematics.
-                    initiatorRole: student
-                    receiver:
-                      address:
-                        country: USA
-                        city: Massachusetts
-                      mainSubjects:
-                        student: []
-                        tutor:
-                          - category: 64884f4dfdc2d1a130c24ac6
-                            subjects:
-                              - 6675874d59019cd05eb11a16
-                              - 65660fbbcb972798c401a9b4
-                            _id: 6675a09d83835d79e960087a
-                          - category: 64884f98fdc2d1a130c24ad4
-                            subjects:
-                              - 66758d6e59019cd05eb11a5d
-                            _id: 6675a08e83835d79e9600842
-                          - category: 64884f33fdc2d1a130c24ac2
-                            subjects:
-                              - 6566133a2bccdd3e18dbe943
-                            _id: 6675a06f83835d79e96007fc
-                      totalReviews:
-                        student: 10
-                        tutor: 8
-                      averageRating:
-                        student: 4.5
-                        tutor: 4.9
-                      status:
-                        student: active
-                        tutor: active
-                        admin: active
-                      videoLink:
-                        tutor: https://www.youtube.com/watch?v=ebTnuLRnIOY-JaneRoe
-                      professionalBlock:
-                        awards: The best tutor of the year 2023
-                        scientificActivities: The author of the scientific work 'The role of mathematics in the development of society'
-                        workExperience: I have been tutoring students in Mathematics for over 5 years and have helped many students achieve their academic goals.
-                        education: The University of Cambridge, Bachelor of Mathematics
-                      notificationSettings:
-                        isOfferStatusNotification: true
-                        isChatNotification: true
-                        isSimilarOffersNotification: true
-                        isEmailNotification: true
-                      _id: 6658f73f93885febb491e08b
-                      role:
-                        - tutor
-                      firstName: Jane
-                      lastName: Roe
-                      email: jane_roe@gmail.com
-                      nativeLanguage: null
-                      lastLogin: 2024-09-06T21:08:58.254Z
-                      createdAt: 2024-05-30T22:01:35.360Z
-                      updatedAt: 2024-09-06T21:08:58.256Z
-                      photo: 6658f73f938-test_tutor.png
-                      professionalSummary: Recently graduated from the University of Cambridge with a degree in Mathematics. I have been tutoring students in Mathematics for over 5 years and have helped many students achieve their academic goals. I am passionate about teaching and enjoy helping students understand complex mathematical concepts. I believe that every student has the potential to succeed and I am committed to helping them reach their full potential.
-                    receiverRole: tutor
-                    title: Understanding Quadratic Equations
-                    proficiencyLevel: Intermediate
-                    price: 150
-                    status: active
-                    needAction: tutor
-                    availableQuizzes: []
-                    finishedQuizzes: []
-                    sections:
-                      - title: Section title
-                        description: Section description
-                        resources:
-                          - resource:
-                              title: Colors in English
-                              description: With this lesson you will learn all about colors in English.
-                              content: <h1>Title</h1>
-                              author: 63da8767c9ad4c9a0b0eacd3
-                              attachments:
-                                - 63ed1cd25e9d781cdb6a6b15
-                              category:
-                                _id: 6477007a6fa4d05e1a800ce1
-                                name: Languages
-                              _id: 63ed1cd25e9d781cdb6a6b17
-                            resourceType: lesson
-                            availability:
-                              status: open
-                              date: null
-                          - resource:
-                              _id: 674ea3bfee3f962bc6854f2d
-                              author: 674d29abfc17e913ec1b25ca
-                              fileName: file1.pdf
-                              link: 1733181402666-file1.pdf
-                              size: 1189396
-                              category: null
-                              resourceType: attachment
-                              isDuplicate: true
-                            resourceType: attachment
-                            availability:
-                              status: closed
-                              date: null
-                          - resource:
-                              _id: 674ea3bfee3f962bc6854f2c
-                              author: 674d29abfc17e913ec1b25ca
-                              fileName: file2.pdf
-                              link: 1733181402666-file2.pdf
-                              size: 1189396
-                              category: null
-                              resourceType: attachment
-                              isDuplicate: true
-                            resourceType: attachment
-                            availability:
-                              status: openFrom
-                              date: 2024-09-06T15:27:29.999Z
-                        _id: 674cae6458b8af8857ffac8a
-                    createdAt: 2024-07-02T16:29:40.956Z
-                    updatedAt: 2024-09-06T15:27:29.999Z
+                $ref: '#/definitions/cooperationResponse'
+              example:
+                _id: 8755bc080a00adr9243df106
+                description: "I'll teach you how to play violin"
+                languages: ['English']
+                subject: { name: 'Music' }
+                category: { appearance: { color: '#E3B21C', icon: 'ScienceRoundedIcon' } }
+                offer:
+                  {
+                    _id: 63ebc6fbd2f34037d0aba791,
+                    author:
+                      {
+                        _id: '66a7abbab3168fa64a8f5af1',
+                        averageRating: { student: 0, tutor: 0 },
+                        firstName: 'John',
+                        lastName: 'Doe',
+                        photo: '1726302583778-pexels-vanessa-garcia-6326377.jpg',
+                        professionalSummary: 'I have 12 years of experience',
+                        totalReviews: { student: 0, tutor: 0 }
+                      }
+                  }
+                initiator:
+                  address:
+                    country: 'USA'
+                    city: 'California'
+                  mainSubjects:
+                    student: []
+                    tutor: []
+                  totalReviews:
+                    student: 8
+                    tutor: 7.5
+                  averageRating:
+                    student: 5
+                    tutor: 4.9
+                  status:
+                    student: 'active'
+                    tutor: 'active'
+                    admin: 'active'
+                  videoLink:
+                    student: 'https://www.youtube.com/watch?v=ebTnuLRnIOY-JohnDoe'
+                  professionalBlock:
+                    awards: 'Gold medal in mathematics competition'
+                    scientificActivities: 'Founded the Math Club at the University of Cambridge'
+                    workExperience: 'n/a'
+                    education: 'Working towards a Bachelor of Mathematics at the University of Cambridge'
+                  notificationSettings:
+                    isOfferStatusNotification: true
+                    isChatNotification: true
+                    isSimilarOffersNotification: true
+                    isEmailNotification: true
+                  _id: 6658f6b793885febb491e07c
+                  role:
+                    - 'student'
+                  firstName: 'John'
+                  lastName: 'Doe'
+                  email: 'john_doe@gmail.com'
+                  nativeLanguage: English
+                  lastLogin: '2024-08-06T13:47:50.872Z'
+                  createdAt: '2024-05-30T21:59:19.434Z'
+                  updatedAt: '2024-08-06T13:47:50.872Z'
+                  professionalSummary: 'I am a student at the University of Cambridge studying Mathematics. I am passionate about learning mathematics.'
+                initiatorRole: 'student'
+                receiver:
+                  address:
+                    country: 'USA'
+                    city: 'Massachusetts'
+                  mainSubjects:
+                    student: []
+                    tutor:
+                      - category: '64884f4dfdc2d1a130c24ac6'
+                        subjects:
+                          - '6675874d59019cd05eb11a16'
+                          - '65660fbbcb972798c401a9b4'
+                        _id: '6675a09d83835d79e960087a'
+                      - category: '64884f98fdc2d1a130c24ad4'
+                        subjects:
+                          - '66758d6e59019cd05eb11a5d'
+                        _id: '6675a08e83835d79e9600842'
+                      - category: '64884f33fdc2d1a130c24ac2'
+                        subjects:
+                          - '6566133a2bccdd3e18dbe943'
+                        _id: '6675a06f83835d79e96007fc'
+                  totalReviews:
+                    student: 10
+                    tutor: 8
+                  averageRating:
+                    student: 4.5
+                    tutor: 4.9
+                  status:
+                    student: 'active'
+                    tutor: 'active'
+                    admin: 'active'
+                  videoLink:
+                    tutor: 'https://www.youtube.com/watch?v=ebTnuLRnIOY-JaneRoe'
+                  professionalBlock:
+                    awards: 'The best tutor of the year 2023'
+                    scientificActivities: "The author of the scientific work 'The role of mathematics in the development of society'"
+                    workExperience: 'I have been tutoring students in Mathematics for over 5 years and have helped many students achieve their academic goals.'
+                    education: 'The University of Cambridge, Bachelor of Mathematics'
+                  notificationSettings:
+                    isOfferStatusNotification: true
+                    isChatNotification: true
+                    isSimilarOffersNotification: true
+                    isEmailNotification: true
+                  _id: 6658f73f93885febb491e08b
+                  role:
+                    - 'tutor'
+                  firstName: 'Jane'
+                  lastName: 'Roe'
+                  email: 'jane_roe@gmail.com'
+                  nativeLanguage: null
+                  lastLogin: '2024-09-06T21:08:58.254Z'
+                  createdAt: '2024-05-30T22:01:35.360Z'
+                  updatedAt: '2024-09-06T21:08:58.256Z'
+                  photo: '6658f73f938-test_tutor.png'
+                  professionalSummary: 'Recently graduated from the University of Cambridge with a degree in Mathematics. I have been tutoring students in Mathematics for over 5 years and have helped many students achieve their academic goals. I am passionate about teaching and enjoy helping students understand complex mathematical concepts. I believe that every student has the potential to succeed and I am committed to helping them reach their full potential.'
+                receiverRole: 'tutor'
+                title: 'Understanding Quadratic Equations'
+                proficiencyLevel: ['Intermediate']
+                price: 150
+                status: 'active'
+                needAction: 'tutor'
+                availableQuizzes: []
+                finishedQuizzes: []
+                sections:
+                  - title: Section title
+                    description: Section description
+                    resources:
+                      - resource:
+                          title: Colors in English
+                          description: With this lesson you will learn all about colors in English.
+                          content: <h1>Title</h1>
+                          author: 63da8767c9ad4c9a0b0eacd3
+                          attachments:
+                            - 63ed1cd25e9d781cdb6a6b15
+                          category:
+                            _id: 6477007a6fa4d05e1a800ce1
+                            name: Languages
+                          _id: 63ed1cd25e9d781cdb6a6b17
+                        resourceType: lesson
+                        availability:
+                          status: open
+                          date: 2022-10-18T13:25:36.292+00:00
+                createdAt: '2024-07-02T16:29:40.956Z'
+                updatedAt: '2024-09-06T15:27:29.999Z'
         400:
           description: Bad Request
           content:

--- a/docs/courses-cooperations/courses-cooperations.schema.yaml
+++ b/docs/courses-cooperations/courses-cooperations.schema.yaml
@@ -100,7 +100,19 @@ definitions:
             price:
               type: number
             proficiencyLevel:
+              type: array
+              items:
+                type: string
+            subject:
               type: string
+            category:
+              type: string
+            description:
+              type: string
+            languages:
+              type: array
+              items:
+                type: string
             receiver:
               type: string
             receiverRole:

--- a/docs/courses-cooperations/courses-cooperations.yaml
+++ b/docs/courses-cooperations/courses-cooperations.yaml
@@ -28,7 +28,11 @@ paths:
                       needAction: 'tutor',
                       offer: '66ec53d40d9d9983a9525421',
                       price: 500,
-                      proficiencyLevel: 'Beginner',
+                      proficiencyLevel: ['Beginner'],
+                      description: "I'll teach you how to follow healthy diet",
+                      languages: ['English'],
+                      subject: '656605be8bebd72f0be55a3d',
+                      category: '6566040f8bebd72f0be55a28',
                       receiver: '66a7abbab3168fa64a8f5af1',
                       receiverRole: 'tutor',
                       sections:

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,5 +34,6 @@ module.exports = {
     '<rootDir>/src/test/migrations/*.spec.js',
     '!<rootDir>/src/test/integration/models/**/*.spec.js'
   ],
-  testResultsProcessor: 'jest-sonar-reporter'
+  testResultsProcessor: 'jest-sonar-reporter',
+  workerIdleMemoryLimit: '512MB'
 }

--- a/migrations/20241106160527-add-fields-to-cooperations.js
+++ b/migrations/20241106160527-add-fields-to-cooperations.js
@@ -1,0 +1,48 @@
+module.exports = {
+  async up(db) {
+    await db
+      .collection('cooperation')
+      .aggregate([
+        {
+          $lookup: {
+            from: 'offers',
+            localField: 'offer',
+            foreignField: '_id',
+            as: '_tmp_offers_array'
+          }
+        },
+        { $set: { _tmp_offer: { $first: '$_tmp_offers_array' } } },
+        {
+          $set: {
+            subject: '$_tmp_offer.subject',
+            category: '$_tmp_offer.category',
+            description: '$_tmp_offer.description',
+            languages: '$_tmp_offer.languages',
+            proficiencyLevel: '$_tmp_offer.proficiencyLevel'
+          }
+        },
+        {
+          $project: {
+            subject: 1,
+            category: 1,
+            description: 1,
+            languages: 1,
+            proficiencyLevel: 1
+          }
+        },
+        { $merge: { into: 'cooperation', on: '_id' } }
+      ])
+      .toArray()
+  },
+
+  async down(db) {
+    await db.collection('cooperation').updateMany({}, [
+      {
+        $unset: ['subject', 'category', 'description', 'languages']
+      },
+      {
+        $set: { proficiencyLevel: { $first: '$proficiencyLevel' } }
+      }
+    ])
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "jest": "^29.7.0",
         "jest-sonar-reporter": "^2.0.0",
         "lint-staged": "^15.5.0",
+        "migrate-mongo": "^11.0.0",
         "nodemon": "^3.1.9",
         "prettier": "2.5.1",
         "supertest": "^6.2.4"
@@ -112,646 +113,664 @@
         "openapi-types": ">=7"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
+        "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "tslib": "^1.11.1"
       }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^1.11.1"
       }
     },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
     "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.787.0.tgz",
-      "integrity": "sha512-7v6nywZ5wcQxX7qdZ5M1ld15QdkzLU6fAKiEqbvJKu4dM8cFW6As+DbS990Mg46pp1xM/yvme+51xZDTfTfJZA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.515.0.tgz",
+      "integrity": "sha512-e51ImjjRLzXkPEYguvGCbhWPNhoV2OGS6mKHCR940XEeImt04yE1tytYP1vXYpPICmuYgz79BV0FOC9J5N9bvg==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-node": "3.787.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.787.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.787.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.787.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/credential-provider-node": "3.515.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.787.0.tgz",
-      "integrity": "sha512-L8R+Mh258G0DC73ktpSVrG4TT9i2vmDLecARTDR/4q5sRivdDQSL5bUp3LKcK80Bx+FRw3UETIlX6mYMLL9PJQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.515.0.tgz",
+      "integrity": "sha512-4oGBLW476zmkdN98lAns3bObRNO+DLOfg4MDUSR6l6GYBV/zGAtoy2O/FhwYKgA2L5h2ZtElGopLlk/1Q0ePLw==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.787.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.787.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.787.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.515.0.tgz",
+      "integrity": "sha512-zACa8LNlPUdlNUBqQRf5a3MfouLNtcBfm84v2c8M976DwJrMGONPe1QjyLLsD38uESQiXiVQRruj/b000iMXNw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.515.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.515.0.tgz",
+      "integrity": "sha512-ScYuvaIDgip3atOJIA1FU2n0gJkEdveu1KrrCPathoUCV5zpK8qQmO/n+Fj/7hKFxeKdFbB+4W4CsJWYH94nlg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.515.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
-      "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+      "version": "3.513.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.513.0.tgz",
+      "integrity": "sha512-L+9DL4apWuqNKVOMJ8siAuWoRM9rZf9w1iPv8S2o83WO2jVK7E/m+rNW1dFo9HsA5V1ccDl2H2qLXx24HiHmOw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
+        "@smithy/core": "^1.3.2",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.787.0.tgz",
-      "integrity": "sha512-nF5XjgvZHFuyttOeTjMgfEsg6slZPQ6uI34yzq12Kq4icFgcD4bQsijnQClMN7A0u5qR8Ad8kume4b7+I2++Ig==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.515.0.tgz",
+      "integrity": "sha512-pWMJFhNc6bLbCpKhYXWWa23wMyhpFFyw3kF/6ea+95JQHF0FY2l4wDQa7ynE4hW4Wf5oA3Sf7Wf87pp9iAHubQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.787.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/client-cognito-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
-      "integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.515.0.tgz",
+      "integrity": "sha512-45vxdyqhTAaUMERYVWOziG3K8L2TV9G4ryQS/KZ84o7NAybE9GMdoZRVmGHAO7mJJ1wQiYCM/E+i5b3NW9JfNA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
-      "integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.515.0.tgz",
+      "integrity": "sha512-Ba6FXK77vU4WyheiamNjEuTFmir0eAXuJGPO27lBaA8g+V/seXGHScsbOG14aQGDOr2P02OPwKGZrWWA7BFpfQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.787.0.tgz",
-      "integrity": "sha512-hc2taRoDlXn2uuNuHWDJljVWYrp3r9JF1a/8XmOAZhVUNY+ImeeStylHXhXXKEA4JOjW+5PdJj0f1UDkVCHJiQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.515.0.tgz",
+      "integrity": "sha512-ouDlNZdv2TKeVEA/YZk2+XklTXyAAGdbWnl4IgN9ItaodWI+lZjdIoNC8BAooVH+atIV/cZgoGTGQL7j2TxJ9A==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.787.0",
-        "@aws-sdk/credential-provider-web-identity": "3.787.0",
-        "@aws-sdk/nested-clients": "3.787.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.787.0.tgz",
-      "integrity": "sha512-JioVi44B1vDMaK2CdzqimwvJD3uzvzbQhaEWXsGMBcMcNHajXAXf08EF50JG3ZhLrhhUsT1ObXpbTaPINOhh+g==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.515.0.tgz",
+      "integrity": "sha512-Y4kHSpbxksiCZZNcvsiKUd8Fb2XlyUuONEwqWFNL82ZH6TCCjBGS31wJQCSxBHqYcOL3tiORUEJkoO7uS30uQA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-ini": "3.787.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.787.0",
-        "@aws-sdk/credential-provider-web-identity": "3.787.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-http": "3.515.0",
+        "@aws-sdk/credential-provider-ini": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
-      "integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.515.0.tgz",
+      "integrity": "sha512-pSjiOA2FM63LHRKNDvEpBRp80FVGT0Mw/gzgbqFXP+sewk0WVonYbEcMDTJptH3VsLPGzqH/DQ1YL/aEIBuXFQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.787.0.tgz",
-      "integrity": "sha512-fHc08bsvwm4+dEMEQKnQ7c1irEQmmxbgS+Fq41y09pPvPh31nAhoMcjBSTWAaPHvvsRbTYvmP4Mf12ZGr8/nfg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.515.0.tgz",
+      "integrity": "sha512-j7vUkiSmuhpBvZYoPTRTI4ePnQbiZMFl6TNhg9b9DprC1zHkucsZnhRhqjOVlrw/H6J4jmcPGcHHTZ5WQNI5xQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.787.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/token-providers": "3.787.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/client-sso": "3.515.0",
+        "@aws-sdk/token-providers": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.787.0.tgz",
-      "integrity": "sha512-SobmCwNbk6TfEsF283mZPQEI5vV2j6eY5tOCj8Er4Lzraxu9fBPADV+Bib2A8F6jlB1lMPJzOuDCbEasSt/RIw==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.515.0.tgz",
+      "integrity": "sha512-66+2g4z3fWwdoGReY8aUHvm6JrKZMTRxjuizljVmMyOBttKPeBYXvUTop/g3ZGUx1f8j+C5qsGK52viYBvtjuQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/nested-clients": "3.787.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.787.0.tgz",
-      "integrity": "sha512-kR3RtI7drOc9pho13vWbUC2Bvrx9A0G4iizBDGmTs08NOdg4w3c1I4kdLG9tyPiIMeVnH+wYrsli5CM7xIfqiA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.515.0.tgz",
+      "integrity": "sha512-XQ9maVLTtv6iJbOYiRS+IvaPlFkJDuxfpfxuky3aPzQpxDilU4cf1CfIDua8qivZKQ4QQOd1EaBMXPIpLI1ZTQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.787.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.787.0",
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-ini": "3.787.0",
-        "@aws-sdk/credential-provider-node": "3.787.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.787.0",
-        "@aws-sdk/credential-provider-web-identity": "3.787.0",
-        "@aws-sdk/nested-clients": "3.787.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/client-cognito-identity": "3.515.0",
+        "@aws-sdk/client-sso": "3.515.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.515.0",
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-http": "3.515.0",
+        "@aws-sdk/credential-provider-ini": "3.515.0",
+        "@aws-sdk/credential-provider-node": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
-      "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.515.0.tgz",
+      "integrity": "sha512-I1MwWPzdRKM1luvdDdjdGsDjNVPhj9zaIytEchjTY40NcKOg+p2evLD2y69ozzg8pyXK63r8DdvDGOo9QPuh0A==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
-      "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.515.0.tgz",
+      "integrity": "sha512-qXomJzg2m/5seQOxHi/yOXOKfSjwrrJSmEmfwJKJyQgdMbBcjz3Cz0H/1LyC6c5hHm6a/SZgSTzDAbAoUmyL+Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
-      "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.515.0.tgz",
+      "integrity": "sha512-dokHLbTV3IHRIBrw9mGoxcNTnQsjlm7TpkJhPdGT9T4Mq399EyQo51u6IsVMm07RXLl2Zw7u+u9p+qWBFzmFRA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.787.0.tgz",
-      "integrity": "sha512-Lnfj8SmPLYtrDFthNIaNj66zZsBCam+E4XiUDr55DIHTGstH6qZ/q6vg0GfbukxwSmUcGMwSR4Qbn8rb8yd77g==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.515.0.tgz",
+      "integrity": "sha512-nOqZjGA/GkjuJ5fUshec9Fv6HFd7ovOTxMJbw3MfAhqXuVZ6dKF41lpVJ4imNsgyFt3shUg9WDY8zGFjlYMB3g==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.787.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.787.0.tgz",
-      "integrity": "sha512-xk03q1xpKNHgbuo+trEf1dFrI239kuMmjKKsqLEsHlAZbuFq4yRGMlHBrVMnKYOPBhVFDS/VineM991XI52fKg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.787.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.787.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.787.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
-      "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.515.0.tgz",
+      "integrity": "sha512-RIRx9loxMgEAc/r1wPfnfShOuzn4RBi8pPPv6/jhhITEeMnJe6enAh2k5y9DdiVDDgCWZgVFSv0YkAIfzAFsnQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.787.0.tgz",
-      "integrity": "sha512-d7/NIqxq308Zg0RPMNrmn0QvzniL4Hx8Qdwzr6YZWLYAbUSvZYS2ppLR3BFWSkV6SsTJUx8BuDaj3P8vttkrog==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.515.0.tgz",
+      "integrity": "sha512-MQuf04rIcTXqwDzmyHSpFPF1fKEzRl64oXtCRUF3ddxTdK6wxXkePfK6wNCuL+GEbEcJAoCtIGIRpzGPJvQjHA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.787.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/client-sso-oidc": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
-      "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
+      "integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.787.0.tgz",
-      "integrity": "sha512-fd3zkiOkwnbdbN0Xp9TsP5SWrmv0SpT70YEdbb8wAj2DWQwiCmFszaSs+YCvhoCdmlR3Wl9Spu0pGpSAGKeYvQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.515.0.tgz",
+      "integrity": "sha512-UJi+jdwcGFV/F7d3+e2aQn5yZOVpDiAgfgNhPnEtgV0WozJ5/ZUeZBgWvSc/K415N4A4D/9cbBc7+I+35qzcDQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.2",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
-      "integrity": "sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==",
+      "version": "3.495.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
+      "integrity": "sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
-      "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.515.0.tgz",
+      "integrity": "sha512-pTWQb0JCafTmLHLDv3Qqs/nAAJghcPdGQIBpsCStb0YEzg3At/dOi2AIQ683yYnXmeOxLXJDzmlsovfVObJScw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.787.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.787.0.tgz",
-      "integrity": "sha512-mG7Lz8ydfG4SF9e8WSXiPQ/Lsn3n8A5B5jtPROidafi06I3ckV2WxyMLdwG14m919NoS6IOfWHyRGSqWIwbVKA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.515.0.tgz",
+      "integrity": "sha512-A/KJ+/HTohHyVXLH+t/bO0Z2mPrQgELbQO8tX+B2nElo8uklj70r5cT7F8ETsI9oOy+HDVpiL5/v45ZgpUOiPg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.787.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -760,6 +779,15 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -1407,6 +1435,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2139,9 +2168,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
-      "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
+      "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -2219,568 +2248,574 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
-      "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
-      "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.2.tgz",
+      "integrity": "sha512-tYDmTp0f2TZVE18jAOH1PnmkngLQ+dOGUlMd1u67s87ieueNeyqhja6z/Z4MxhybEiXKOWFOmGjfTZWFxljwJw==",
       "optional": true,
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
-      "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "tslib": "^2.6.2"
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
-      "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "optional": true,
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
-      "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
-      "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
-      "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "optional": true,
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
-      "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "optional": true,
       "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
-      "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
-      "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
-      "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
-      "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "optional": true,
       "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
-      "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "optional": true,
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
-      "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
-      "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
-      "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
-      "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
-      "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0"
+        "@smithy/types": "^2.9.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
-      "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.0.tgz",
-      "integrity": "sha512-4t5WX60sL3zGJF/CtZsUQTs3UrZEDO2P7pEaElrekbLqkWPYkgqNW1oeiNYC6xXifBnT9dVBOnNQRvOE9riU9w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "optional": true,
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
-      "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "optional": true,
       "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
-      "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "optional": true,
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "optional": true,
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@smithy/util-buffer-from": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "optional": true,
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@smithy/is-array-buffer": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
-      "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "optional": true,
       "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
-      "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+      "integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
       "optional": true,
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
-      "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
-      "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
-      "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "optional": true,
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
-      "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "optional": true,
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "optional": true,
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@smithy/util-buffer-from": "^2.1.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -3652,9 +3687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001717",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "dev": true,
       "funding": [
         {
@@ -3822,6 +3857,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
       "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -3836,6 +3872,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
@@ -3844,12 +3881,14 @@
     "node_modules/cli-table3/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3858,6 +3897,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4187,8 +4227,7 @@
     "node_modules/country-state-city": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/country-state-city/-/country-state-city-3.2.1.tgz",
-      "integrity": "sha512-kxbanqMc6izjhc/EHkGPCTabSPZ2G6eG4/97akAYHJUN4stzzFEvQPZoF8oXDQ+10gM/O/yUmISCR1ZVxyb6EA==",
-      "license": "GPL-3.0"
+      "integrity": "sha512-kxbanqMc6izjhc/EHkGPCTabSPZ2G6eG4/97akAYHJUN4stzzFEvQPZoF8oXDQ+10gM/O/yUmISCR1ZVxyb6EA=="
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -4264,6 +4303,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -4544,9 +4584,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.151",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.151.tgz",
-      "integrity": "sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==",
+      "version": "1.5.155",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
+      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
       "dev": true
     },
     "node_modules/email-templates": {
@@ -5095,17 +5135,17 @@
       "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
         {
           "type": "paypal",
           "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
       "optional": true,
@@ -5261,6 +5301,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fn-args/-/fn-args-5.0.0.tgz",
       "integrity": "sha512-CtbfI3oFFc3nbdIoHycrfbrxiGgxXBXXuyOl49h47JawM1mYrqpiRqnH5CB2mBatdXvHHOUO6a+RiAuuvKt0lw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5305,6 +5346,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5663,7 +5705,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -6963,6 +7006,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -7875,6 +7919,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/migrate-mongo/-/migrate-mongo-11.0.0.tgz",
       "integrity": "sha512-GB/gHzUwp/fL1w6ksNGihTyb+cSrm6NbVLlz1OSkQKaLlzAXMwH7iKK2ZS7W5v+I8vXiY2rL58WTUZSAL6QR+A==",
+      "dev": true,
       "dependencies": {
         "cli-table3": "^0.6.1",
         "commander": "^9.1.0",
@@ -7898,6 +7943,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8138,8 +8184,7 @@
     "node_modules/murmurhash": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
-      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew==",
-      "license": "MIT"
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew=="
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -8502,6 +8547,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
       "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -9238,7 +9284,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/require-at": {
       "version": "1.0.6",
@@ -10633,6 +10680,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jest-sonar-reporter": "^2.0.0",
     "lint-staged": "^15.5.0",
     "nodemon": "^3.1.9",
+    "migrate-mongo": "^11.0.0",
     "prettier": "2.5.1",
     "supertest": "^6.2.4"
   },

--- a/src/models/cooperation.js
+++ b/src/models/cooperation.js
@@ -7,7 +7,7 @@ const {
   FIELD_MUST_BE_SELECTED,
   VALUE_MUST_BE_ABOVE
 } = require('~/consts/errors')
-const { USER, OFFER, COOPERATION, FINISHED_QUIZ, QUIZ } = require('~/consts/models')
+const { USER, OFFER, COOPERATION, FINISHED_QUIZ, QUIZ, SUBJECT, CATEGORY } = require('~/consts/models')
 const {
   enums: {
     COOPERATION_STATUS_ENUM,
@@ -16,7 +16,8 @@ const {
     RESOURCES_TYPES_ENUM,
     RESOURCE_AVAILABILITY_STATUS_ENUM,
     RESOURCE_COMPLETION_STATUS_ENUM,
-    NEED_ACTION_ENUM
+    NEED_ACTION_ENUM,
+    SPOKEN_LANG_ENUM
   }
 } = require('~/consts/validation')
 const { REQUESTED, UPDATED } = require('~/consts/notificationTypes')
@@ -68,7 +69,7 @@ const cooperationSchema = new Schema(
       maxLength: [1000, FIELD_CANNOT_BE_LONGER('additional info', 1000)]
     },
     proficiencyLevel: {
-      type: String,
+      type: [String],
       enum: {
         values: PROFICIENCY_LEVEL_ENUM,
         message: ENUM_CAN_BE_ONE_OF('proficiency level', PROFICIENCY_LEVEL_ENUM)
@@ -117,6 +118,30 @@ const cooperationSchema = new Schema(
     finishedQuizzes: {
       type: [Schema.Types.ObjectId],
       ref: FINISHED_QUIZ
+    },
+    subject: {
+      type: Schema.Types.ObjectId,
+      ref: SUBJECT,
+      required: true
+    },
+    category: {
+      type: Schema.Types.ObjectId,
+      ref: CATEGORY,
+      required: true
+    },
+    description: {
+      type: String,
+      minLength: [1, FIELD_CANNOT_BE_SHORTER('description', 1)],
+      maxLength: [1000, FIELD_CANNOT_BE_LONGER('description', 1000)],
+      required: [true, FIELD_CANNOT_BE_EMPTY('description')]
+    },
+    languages: {
+      type: [String],
+      enum: {
+        values: SPOKEN_LANG_ENUM,
+        message: ENUM_CAN_BE_ONE_OF('language', SPOKEN_LANG_ENUM)
+      },
+      required: [true, FIELD_MUST_BE_SELECTED('language(s)')]
     },
     sections: [
       {

--- a/src/services/cooperation.js
+++ b/src/services/cooperation.js
@@ -39,7 +39,20 @@ const cooperationService = {
   },
 
   createCooperation: async (initiator, initiatorRole, data) => {
-    const { offer, proficiencyLevel, additionalInfo, receiver, receiverRole, price, title, sections } = data
+    const {
+      offer,
+      proficiencyLevel,
+      additionalInfo,
+      receiver,
+      receiverRole,
+      price,
+      title,
+      sections,
+      subject,
+      category,
+      description,
+      languages
+    } = data
 
     const initialNeedAction = {
       role: receiverRole,
@@ -58,6 +71,10 @@ const cooperationService = {
       price,
       proficiencyLevel,
       additionalInfo,
+      subject,
+      category,
+      description,
+      languages,
       needAction: initialNeedAction
     })
   },

--- a/src/test/integration/controllers/attachments.spec.js
+++ b/src/test/integration/controllers/attachments.spec.js
@@ -16,6 +16,7 @@ const {
 const resourcesCategoryService = require('~/services/resourcesCategory')
 const refs = require('~/consts/models')
 const { INVALID_ID } = require('~/consts/errors')
+const { testCooperationData } = require('~/test/test-constants')
 
 jest.mock('@azure/storage-blob', () => {
   const mockBlockBlobClient = {
@@ -391,16 +392,7 @@ describe('Attachments controller', () => {
 
     it('should delete attachment and remove references from all cooperation sections', async () => {
       const cooperationData = {
-        offer: '82a51e41de4debbccf0b3111',
-        initiator: currentUser.id,
-        initiatorRole: 'tutor',
-        receiver: '62a51e41de4debbccf0b3111',
-        receiverRole: 'student',
-        title: 'Web Development Course',
-        proficiencyLevel: 'Beginner',
-        price: 500,
-        status: 'active',
-        needAction: 'student',
+        ...testCooperationData,
         sections: [
           {
             title: 'Start with HTML',

--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -18,6 +18,14 @@ const {
 
 jest.mock('google-auth-library')
 
+const user = {
+  role: 'student',
+  firstName: 'test',
+  lastName: 'test',
+  email: 'test@gmail.com',
+  password: 'testpass_135'
+}
+
 describe('Auth controller', () => {
   let app, server, signupResponse
 
@@ -36,14 +44,6 @@ describe('Auth controller', () => {
   afterAll(async () => {
     await stopServer(server)
   })
-
-  const user = {
-    role: 'student',
-    firstName: 'test',
-    lastName: 'test',
-    email: 'test@gmail.com',
-    password: 'testpass_135'
-  }
 
   describe('Signup endpoint', () => {
     it('should register a user', async () => {
@@ -135,6 +135,7 @@ describe('Auth controller', () => {
       const findConfirmTokenResponse = await tokenService.findTokensWithUsersByParams({
         user: signupResponse.body.userId
       })
+
       confirmToken = findConfirmTokenResponse[0].confirmToken
     })
 

--- a/src/test/integration/controllers/cooperation.spec.js
+++ b/src/test/integration/controllers/cooperation.spec.js
@@ -9,6 +9,7 @@ const { serverCleanup, serverInit, stopServer } = require('~/test/setup')
 const { expectError } = require('~/test/helpers')
 const testUserAuthentication = require('~/utils/testUserAuth')
 const TokenService = require('~/services/token')
+const { testCooperationData } = require('~/test/test-constants')
 
 const { DOCUMENT_NOT_FOUND, UNAUTHORIZED, VALIDATION_ERROR, FORBIDDEN } = require('~/consts/errors')
 const {
@@ -54,11 +55,14 @@ const anotherStudentUserData = {
   lastLoginAs: 'student'
 }
 
-const testCooperationData = {
+const cooperationDataMock = {
+  ...testCooperationData,
   price: 99,
   receiverRole: 'tutor',
-  proficiencyLevel: 'Beginner',
+  proficiencyLevel: ['Beginner'],
   title: 'First-class teacher. Director of the Hogwarts school of magic',
+  description: 'I will teach you how to protect yourself and your family from dark arts',
+  languages: ['English'],
   sections: [
     {
       title: 'Solving Quadratic Equations Using the Quadratic Formula',
@@ -274,16 +278,16 @@ describe('Cooperation controller', () => {
     })
 
     testOffer = await Offer.create({
+      ...testOfferData,
       author: testTutorUser.id,
       subject: subject._id,
-      category: category._id,
-      ...testOfferData
+      category: category._id
     })
 
     testActiveQuiz = await Quiz.create({
+      ...testActiveQuizData,
       author: testTutorUser.id,
-      category: category._id,
-      ...testActiveQuizData
+      category: category._id
     })
 
     const testLessonOpenResource = await Lesson.create({
@@ -313,11 +317,16 @@ describe('Cooperation controller', () => {
       resourceType: RESOURCES_TYPES_ENUM[0]
     })
 
-    const updatedTestCooperationData = {
-      ...testCooperationData,
+    const cedTestCooperationDataMock = {
+      ...cooperationDataMock,
+      subject: subject._id,
+      category: category._id,
+      receiver: testTutorUser.id,
+      receiverRole: tutorUserData.role[0],
+      offer: testOffer._id,
       sections: [
         {
-          ...testCooperationData.sections[0],
+          ...cooperationDataMock.sections[0],
           resources: [
             {
               resource: testLessonOpenResource._id,
@@ -342,13 +351,7 @@ describe('Cooperation controller', () => {
     testCooperation = await app
       .post(endpointUrl)
       .set('Cookie', [`accessToken=${studentAccessToken}`])
-      .send({
-        receiver: testTutorUser.id,
-        receiverRole: tutorUserData.role[0],
-        offer: testOffer._id,
-        sections: updatedTestCooperationData.sections,
-        ...updatedTestCooperationData
-      })
+      .send(cedTestCooperationDataMock)
   })
 
   afterEach(async () => {
@@ -376,20 +379,19 @@ describe('Cooperation controller', () => {
       expect(response.body.count).toBe(1)
       expect(Array.isArray(response.body.items)).toBe(true)
       expect(response.body.items[0]).toMatchObject({
-        _id: testCooperation._body._id.toString(),
-        offer: {
-          _id: testOffer._id.toString()
-        },
-        initiator: testStudentUser.id.toString(),
-        receiver: testTutorUser.id.toString(),
-        proficiencyLevel: testCooperationData.proficiencyLevel,
-        price: testCooperationData.price,
-        title: testCooperationData.title,
+        _id: testCooperation._body._id,
+        offer: expect.any(String),
+        initiator: testStudentUser.id,
+        receiver: testTutorUser.id,
+        proficiencyLevel: cooperationDataMock.proficiencyLevel,
+        price: cooperationDataMock.price,
+        title: cooperationDataMock.title,
         status: 'pending',
         needAction: testNeedAction,
         createdAt: testCooperation._body.createdAt,
         updatedAt: testCooperation._body.updatedAt
       })
+      expect(response.body.items[0].offer.toString()).toBe(testOffer._id.toString())
     })
 
     it('should throw UNAUTHORIZED', async () => {
@@ -407,11 +409,8 @@ describe('Cooperation controller', () => {
 
       expect(response.status).toBe(200)
       expect(response.body).toMatchObject({
-        _id: testCooperation._body._id.toString(),
-        offer: {
-          _id: testOffer._id.toString(),
-          author: { _id: testOffer.author.toString() }
-        },
+        _id: testCooperation._body._id,
+        offer: expect.any(String),
         initiator: {
           ...testInitiator,
           createdAt: expect.any(String),
@@ -427,16 +426,16 @@ describe('Cooperation controller', () => {
           _id: expect.any(String)
         },
         receiverRole: tutorUserData.role[0],
-        proficiencyLevel: testCooperationData.proficiencyLevel,
-        price: testCooperationData.price,
-        title: testCooperationData.title,
+        proficiencyLevel: cooperationDataMock.proficiencyLevel,
+        price: cooperationDataMock.price,
+        title: cooperationDataMock.title,
         status: 'pending',
         needAction: testNeedAction,
         sections: [
           {
             _id: expect.any(String),
-            title: testCooperationData.sections[0].title,
-            description: testCooperationData.sections[0].description,
+            title: cooperationDataMock.sections[0].title,
+            description: cooperationDataMock.sections[0].description,
             resources: [
               {
                 resource: expect.objectContaining({
@@ -448,10 +447,10 @@ describe('Cooperation controller', () => {
                   category: expect.any(String),
                   resourceType: expect.any(String)
                 }),
-                resourceType: testCooperationData.sections[0].resources[0].resourceType,
+                resourceType: cooperationDataMock.sections[0].resources[0].resourceType,
                 availability: {
-                  status: testCooperationData.sections[0].resources[0].availability.status,
-                  date: testCooperationData.sections[0].resources[0].availability.date
+                  status: cooperationDataMock.sections[0].resources[0].availability.status,
+                  date: cooperationDataMock.sections[0].resources[0].availability.date
                 }
               }
             ]
@@ -460,6 +459,7 @@ describe('Cooperation controller', () => {
         createdAt: testCooperation._body.createdAt,
         updatedAt: testCooperation._body.updatedAt
       })
+      expect(response.body.offer.toString()).toBe(testOffer._id.toString())
     })
 
     it('should not send closed resources for student', async () => {
@@ -469,11 +469,8 @@ describe('Cooperation controller', () => {
 
       expect(response.status).toBe(200)
       expect(response.body).toMatchObject({
-        _id: testCooperation._body._id.toString(),
-        offer: {
-          _id: testOffer._id.toString(),
-          author: { _id: testOffer.author.toString() }
-        },
+        _id: testCooperation._body._id,
+        offer: expect.any(String),
         initiator: {
           ...testInitiator,
           createdAt: expect.any(String),
@@ -489,16 +486,16 @@ describe('Cooperation controller', () => {
           _id: expect.any(String)
         },
         receiverRole: tutorUserData.role[0],
-        proficiencyLevel: testCooperationData.proficiencyLevel,
-        price: testCooperationData.price,
-        title: testCooperationData.title,
+        proficiencyLevel: cooperationDataMock.proficiencyLevel,
+        price: cooperationDataMock.price,
+        title: cooperationDataMock.title,
         status: 'pending',
         needAction: testNeedAction,
         sections: [
           {
             _id: expect.any(String),
-            title: testCooperationData.sections[0].title,
-            description: testCooperationData.sections[0].description,
+            title: cooperationDataMock.sections[0].title,
+            description: cooperationDataMock.sections[0].description,
             resources: [
               {
                 resource: expect.objectContaining({
@@ -510,10 +507,10 @@ describe('Cooperation controller', () => {
                   category: expect.any(String),
                   resourceType: expect.any(String)
                 }),
-                resourceType: testCooperationData.sections[0].resources[0].resourceType,
+                resourceType: cooperationDataMock.sections[0].resources[0].resourceType,
                 availability: {
-                  status: testCooperationData.sections[0].resources[0].availability.status,
-                  date: testCooperationData.sections[0].resources[0].availability.date
+                  status: cooperationDataMock.sections[0].resources[0].availability.status,
+                  date: cooperationDataMock.sections[0].resources[0].availability.date
                 }
               }
             ]
@@ -522,6 +519,7 @@ describe('Cooperation controller', () => {
         createdAt: testCooperation._body.createdAt,
         updatedAt: testCooperation._body.updatedAt
       })
+      expect(response.body.offer.toString()).toBe(testOffer._id.toString())
     })
 
     it('should send closed resources for tutor', async () => {
@@ -531,11 +529,8 @@ describe('Cooperation controller', () => {
 
       expect(response.status).toBe(200)
       expect(response.body).toMatchObject({
-        _id: testCooperation._body._id.toString(),
-        offer: {
-          _id: testOffer._id.toString(),
-          author: { _id: testOffer.author.toString() }
-        },
+        _id: testCooperation._body._id,
+        offer: expect.any(String),
         initiator: {
           ...testInitiator,
           createdAt: expect.any(String),
@@ -551,12 +546,12 @@ describe('Cooperation controller', () => {
           _id: expect.any(String)
         },
         receiverRole: tutorUserData.role[0],
-        proficiencyLevel: testCooperationData.proficiencyLevel,
-        price: testCooperationData.price,
-        title: testCooperationData.title,
+        proficiencyLevel: cooperationDataMock.proficiencyLevel,
+        price: cooperationDataMock.price,
+        title: cooperationDataMock.title,
         status: 'pending',
         needAction: testNeedAction,
-        sections: testCooperationData.sections.map((section) => {
+        sections: cooperationDataMock.sections.map((section) => {
           return {
             _id: expect.any(String),
             title: section.title,
@@ -584,6 +579,7 @@ describe('Cooperation controller', () => {
         createdAt: testCooperation._body.createdAt,
         updatedAt: testCooperation._body.updatedAt
       })
+      expect(response.body.offer.toString()).toBe(testOffer._id.toString())
     })
 
     it('should throw DOCUMENT_NOT_FOUND', async () => {
@@ -605,17 +601,17 @@ describe('Cooperation controller', () => {
     it('should create new cooperation', () => {
       expect(testCooperation.status).toBe(201)
       expect(testCooperation.body).toMatchObject({
-        _id: testCooperation._body._id.toString(),
-        offer: testOffer._id.toString(),
-        initiator: testStudentUser.id.toString(),
-        receiver: testTutorUser.id.toString(),
+        _id: testCooperation._body._id,
+        offer: expect.any(String),
+        initiator: testStudentUser.id,
+        receiver: testTutorUser.id,
         receiverRole: tutorUserData.role[0],
-        proficiencyLevel: testCooperationData.proficiencyLevel,
-        price: testCooperationData.price,
-        title: testCooperationData.title,
+        proficiencyLevel: cooperationDataMock.proficiencyLevel,
+        price: cooperationDataMock.price,
+        title: cooperationDataMock.title,
         status: 'pending',
         needAction: testNeedAction,
-        sections: testCooperationData.sections.map((section) => ({
+        sections: cooperationDataMock.sections.map((section) => ({
           _id: expect.any(String),
           title: section.title,
           description: section.description,
@@ -628,6 +624,7 @@ describe('Cooperation controller', () => {
         createdAt: testCooperation._body.createdAt,
         updatedAt: testCooperation._body.updatedAt
       })
+      expect(testCooperation.body.offer.toString()).toBe(testOffer._id.toString())
     })
 
     it('should throw DOCUMENT_NOT_FOUND for offer entity', async () => {
@@ -635,10 +632,10 @@ describe('Cooperation controller', () => {
         .post(endpointUrl)
         .set('Cookie', [`accessToken=${studentAccessToken}`])
         .send({
+          ...cooperationDataMock,
           initiator: testStudentUser.id,
           receiver: testTutorUser.id,
-          offer: nonExistingOfferId,
-          ...testCooperationData
+          offer: nonExistingOfferId
         })
 
       expectError(404, DOCUMENT_NOT_FOUND([Offer.modelName]), response)

--- a/src/test/integration/controllers/coursesCooperations.spec.js
+++ b/src/test/integration/controllers/coursesCooperations.spec.js
@@ -1,5 +1,6 @@
 const { serverCleanup, serverInit, stopServer } = require('~/test/setup')
 const { createUser, getCategory } = require('~/test/test-utils')
+const { testCooperationData } = require('~/test/test-constants')
 const subjectService = require('~/services/subject')
 const Cooperation = require('~/models/cooperation')
 const {
@@ -62,25 +63,14 @@ const testOffer = {
   }
 }
 
-const testCooperation = {
-  offer: 'offerId',
-  initiatorRole: 'student',
-  receiver: 'tutorId',
-  receiverRole: 'tutor',
-  title: 'Cooperation title',
-  proficiencyLevel: 'Beginner',
-  price: 500,
-  status: 'active',
-  availableQuizzes: [],
-  finishedQuizzes: [],
-  sections: [
-    {
-      title: 'Section 1',
-      description: 'description',
-      resources: []
-    }
-  ]
-}
+const testCooperation = { ...testCooperationData }
+testCooperation.sections = [
+  {
+    title: 'Section 1',
+    description: 'description',
+    resources: []
+  }
+]
 
 describe('User controller', () => {
   let app, server, accessToken, userId, testLessonResponse, testLessonId, category, categoryId, testSubject, offerId
@@ -122,6 +112,8 @@ describe('User controller', () => {
 
     testCooperation.receiver = userId
     testCooperation.offer = offerId
+    testCooperation.subject = testSubject._id
+    testCooperation.category = categoryId
   })
 
   afterEach(async () => {

--- a/src/test/integration/controllers/finishedQuiz.spec.js
+++ b/src/test/integration/controllers/finishedQuiz.spec.js
@@ -10,6 +10,7 @@ const {
   roles: { TUTOR, STUDENT }
 } = require('~/consts/auth')
 const TokenService = require('~/services/token')
+const { testCooperationData } = require('~/test/test-constants')
 
 const endpointUrl = '/finished-quizzes/'
 const nonExistingQuiz = '64cf8a3d40135fba5a0c8fa2'
@@ -81,6 +82,7 @@ const testInitiator = {
 }
 
 const cooperationMockData = {
+  ...testCooperationData,
   title: 'Violin lessons',
   proficiencyLevel: 'Test Preparation',
   offer: '63ebc6fbd2f34037d0aba791',

--- a/src/test/integration/controllers/lesson.spec.js
+++ b/src/test/integration/controllers/lesson.spec.js
@@ -7,6 +7,7 @@ const cooperationService = require('~/services/cooperation')
 const TokenService = require('~/services/token')
 const { roles } = require('~/consts/auth')
 const resourceType = require('~/consts/resourceType')
+const { testCooperationData } = require('~/test/test-constants')
 
 const endpointUrl = '/lessons/'
 const nonExistingLessonId = '64a51e41de4debbccf0b39b0'
@@ -163,6 +164,7 @@ describe('Lesson controller', () => {
 
     it('should delete lesson and remove references from all cooperation sections', async () => {
       const cooperationData = {
+        ...testCooperationData,
         offer: '82a51e41de4debbccf0b3111',
         initiator: currentUser.id,
         initiatorRole: 'tutor',

--- a/src/test/integration/controllers/note.spec.js
+++ b/src/test/integration/controllers/note.spec.js
@@ -3,9 +3,13 @@ const { expectError } = require('~/test/helpers')
 const { UNAUTHORIZED, FORBIDDEN, DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 const testUserAuthentication = require('~/utils/testUserAuth')
 const TokenService = require('~/services/token')
+const subjectService = require('~/services/subject')
+const { getCategory } = require('~/test/test-utils')
+const { testCooperationData } = require('~/test/test-constants')
 
 const Cooperation = require('~/models/cooperation')
 const Note = require('~/models/note')
+const User = require('~/models/user')
 
 const endpointUrl = (id = ':id', noteId = '') => `/cooperations/${id}/notes/${noteId}`
 
@@ -19,7 +23,8 @@ const testNeedAction = {
   messages: []
 }
 
-const testCooperationData = {
+const cooperationDataMock = {
+  ...testCooperationData,
   price: 99,
   receiverRole: 'tutor',
   proficiencyLevel: 'Beginner',
@@ -42,8 +47,38 @@ const updateNoteData = {
   isPrivate: true
 }
 
+const subjectBody = { name: 'English' }
+
+const testOffer = {
+  price: 330,
+  proficiencyLevel: ['Beginner'],
+  title: 'Test Title',
+  author: '',
+  authorRole: 'tutor',
+  FAQ: [{ question: 'question1', answer: 'answer1' }],
+  description: 'description',
+  languages: ['Ukrainian'],
+  enrolledUsers: [],
+  subject: '',
+  category: {
+    _id: '',
+    appearance: { icon: 'mocked-path-to-icon', color: '#66C42C' }
+  }
+}
+
+const tutorUserData = {
+  role: ['tutor'],
+  firstName: 'albus',
+  lastName: 'dumbledore',
+  email: 'lovemagic@gmail.com',
+  password: 'supermagicpass123',
+  appLanguage: 'en',
+  isEmailConfirmed: true,
+  lastLogin: new Date().toJSON()
+}
+
 describe('Note controller', () => {
-  let app, server, accessToken, testUser, testCooperation, testNote
+  let app, server, accessToken, testUser, testCooperation, testNote, category, testSubject
 
   beforeAll(async () => {
     ;({ app, server } = await serverInit())
@@ -51,12 +86,30 @@ describe('Note controller', () => {
 
   beforeEach(async () => {
     accessToken = await testUserAuthentication(app)
+    const testTutorUser = await User.create(tutorUserData)
 
     testUser = TokenService.validateAccessToken(accessToken)
 
+    category = await getCategory()
+
+    subjectBody.category = category._id
+    testSubject = await subjectService.addSubject(subjectBody)
+
+    testOffer.category = category._id
+    testOffer.subject = testSubject._id
+    const testOfferResponse = await app
+      .post('/offers/')
+      .set('Cookie', [`accessToken=${accessToken}`])
+      .send(testOffer)
+
+    cooperationDataMock.category = category._id
+    cooperationDataMock.subject = testSubject._id
+    cooperationDataMock.offer = testOfferResponse.body._id
+    cooperationDataMock.receiver = testTutorUser._id
+
     testCooperation = await Cooperation.create({
-      initiator: testUser.id,
-      ...testCooperationData
+      ...cooperationDataMock,
+      initiator: testUser.id
     })
 
     testNote = await app
@@ -88,15 +141,16 @@ describe('Note controller', () => {
           firstName: expect.any(String),
           lastName: expect.any(String)
         },
-        cooperation: testCooperation._id.toString(),
+        cooperation: expect.any(String),
         createdAt: expect.any(String),
         updatedAt: expect.any(String)
       })
+      expect(response.body[0].cooperation.toString()).toBe(testCooperation._id.toString())
     })
 
     it('should throw FORBIDDEN', async () => {
       const cooperation = await Cooperation.create({
-        ...testCooperationData,
+        ...cooperationDataMock,
         initiator: mockedInitiatorId
       })
 
@@ -127,15 +181,16 @@ describe('Note controller', () => {
         _id: testNote._body._id,
         text: expect.any(String),
         author: testUser.id,
-        cooperation: testCooperation._id.toString(),
+        cooperation: expect.any(String),
         createdAt: expect.any(String),
         updatedAt: expect.any(String)
       })
+      expect(testNote.body.cooperation.toString()).toBe(testCooperation._id.toString())
     })
 
     it('should throw FORBIDDEN', async () => {
       const cooperation = await Cooperation.create({
-        ...testCooperationData,
+        ...cooperationDataMock,
         initiator: mockedInitiatorId
       })
 
@@ -177,7 +232,7 @@ describe('Note controller', () => {
 
     it('should throw FORBIDDEN', async () => {
       const cooperation = await Cooperation.create({
-        ...testCooperationData,
+        ...cooperationDataMock,
         initiator: mockedInitiatorId
       })
 
@@ -216,7 +271,7 @@ describe('Note controller', () => {
 
     it('should throw FORBIDDEN if cooperation doesn`t exist', async () => {
       const cooperation = await Cooperation.create({
-        ...testCooperationData,
+        ...cooperationDataMock,
         initiator: mockedInitiatorId
       })
 

--- a/src/test/integration/controllers/quiz.spec.js
+++ b/src/test/integration/controllers/quiz.spec.js
@@ -12,6 +12,7 @@ const {
 const resourceType = require('~/consts/resourceType')
 const { roles } = require('~/consts/auth')
 const cooperationService = require('~/services/cooperation')
+const { testCooperationData } = require('~/test/test-constants')
 
 const endpointUrl = '/quizzes/'
 const questionEndpointUrl = '/questions/'
@@ -258,16 +259,7 @@ describe('Quiz controller', () => {
 
     it('should delete lesson and remove references from all cooperation sections', async () => {
       const cooperationData = {
-        offer: '82a51e41de4debbccf0b3111',
-        initiator: currentUser.id,
-        initiatorRole: 'tutor',
-        receiver: '62a51e41de4debbccf0b3111',
-        receiverRole: 'student',
-        title: 'Web Development Course',
-        proficiencyLevel: 'Beginner',
-        price: 500,
-        status: 'active',
-        needAction: 'student',
+        ...testCooperationData,
         sections: [
           {
             title: 'Start with HTML',

--- a/src/test/integration/controllers/review.spec.js
+++ b/src/test/integration/controllers/review.spec.js
@@ -12,6 +12,7 @@ const {
 const {
   roles: { TUTOR, ADMIN }
 } = require('~/consts/auth')
+const { testCooperationData } = require('~/test/test-constants')
 
 const endpointUrl = '/reviews/'
 const offerEndpointUrl = '/offers/'
@@ -50,10 +51,10 @@ let offerBody = {
 }
 
 let cooperationBody = {
+  ...testCooperationData,
   title: 'Test title',
   price: 99,
-  receiverRole: 'tutor',
-  proficiencyLevel: 'Intermediate'
+  receiverRole: 'tutor'
 }
 
 let subjectBody = {
@@ -210,7 +211,7 @@ describe('Review controller', () => {
                 name: 'English'
               }
             },
-            proficiencyLevel: 'Intermediate',
+            proficiencyLevel: ['Beginner'],
             createdAt: expect.any(String),
             updatedAt: expect.any(String)
           }
@@ -252,7 +253,7 @@ describe('Review controller', () => {
             name: 'English'
           }
         },
-        proficiencyLevel: 'Intermediate',
+        proficiencyLevel: ['Beginner'],
         createdAt: expect.any(String),
         updatedAt: expect.any(String)
       })

--- a/src/test/integration/controllers/user.spec.js
+++ b/src/test/integration/controllers/user.spec.js
@@ -28,6 +28,7 @@ const cooperationService = require('~/services/cooperation')
 
 const userService = require('~/services/user')
 const { deleteUser } = require('~/controllers/user')
+const { testCooperationData } = require('~/test/test-constants')
 
 const endpointUrl = '/users/'
 const logoutEndpoint = '/auth/logout'
@@ -1055,6 +1056,7 @@ describe('User controller', () => {
       const offer = await offerService.createOffer(offerAuthorId, offerAuthorRole, offerData)
 
       const cooperationData = {
+        ...testCooperationData,
         user: currentUser.id,
         offer: offer._id,
         status: 'active',

--- a/src/test/integration/models/cooperation.spec.js
+++ b/src/test/integration/models/cooperation.spec.js
@@ -69,7 +69,7 @@ describe('Cooperation model', () => {
       expect(typeof cooperation.receiverRole).toBe('string')
       expect(typeof cooperation.title).toBe('string')
       if (cooperation.proficiencyLevel) {
-        expect(typeof cooperation.proficiencyLevel).toBe('string')
+        expect(typeof cooperation.proficiencyLevel).toBe('object')
       }
       expect(typeof cooperation.price).toBe('number')
       expect(typeof cooperation.status).toBe('string')
@@ -176,7 +176,10 @@ describe('Cooperation model', () => {
     for (const cooperation of cooperations) {
       if (cooperation.proficiencyLevel) {
         const proficiencyLevel = cooperation.proficiencyLevel
-        expect(PROFICIENCY_LEVEL_ENUM).toContain(proficiencyLevel)
+
+        proficiencyLevel.forEach((level) => {
+          expect(PROFICIENCY_LEVEL_ENUM).toContain(level)
+        })
       }
     }
   })

--- a/src/test/migrations/20241106160527-add-fields-to-cooperations.spec.js
+++ b/src/test/migrations/20241106160527-add-fields-to-cooperations.spec.js
@@ -1,0 +1,89 @@
+const { MongoClient } = require('mongodb')
+
+const { up, down } = require('@root/migrations/20241106160527-add-fields-to-cooperations.js')
+
+require('~/initialization/envSetup')
+const {
+  config: { MONGODB_URL }
+} = require('~/configs/config')
+const {
+  testCategoryData,
+  testSubjectData,
+  collectionNames: { SUBJECTS, CATEGORIES, OFFERS, COOPERATIONS }
+} = require('~/test/test-constants')
+
+const url = MONGODB_URL.slice(0, MONGODB_URL.lastIndexOf('/'))
+const databaseName = MONGODB_URL.slice(MONGODB_URL.lastIndexOf('/') + 1)
+
+const testOfferData = {
+  subject: 'subjectId',
+  category: 'categoryId',
+  description: 'Offer description',
+  languages: ['English'],
+  proficiencyLevel: ['Beginner']
+}
+
+const testCooperationData = {
+  title: 'Cooperation title',
+  proficiencyLevel: 'Beginner'
+}
+
+describe('20241106160527-add-fields-to-cooperations:', () => {
+  let client, database, testSubjectId, testCategoryId, testCooperationId
+
+  beforeAll(() => {
+    client = new MongoClient(url)
+    database = client.db(databaseName)
+  })
+
+  beforeEach(async () => {
+    const testCategory = await database.collection(CATEGORIES).insertOne(testCategoryData)
+    testCategoryId = testCategory.insertedId
+
+    const testSubjectDataCopy = { ...testSubjectData, category: testCategory.insertedId }
+    const testSubject = await database.collection(SUBJECTS).insertOne(testSubjectDataCopy)
+    testSubjectId = testSubject.insertedId
+
+    testOfferData.subject = testSubject.insertedId
+    testOfferData.category = testCategory.insertedId
+    const testOffer = await database.collection(OFFERS).insertOne(testOfferData)
+
+    const testCooperation = await database
+      .collection(COOPERATIONS)
+      .insertOne({ ...testCooperationData, offer: testOffer.insertedId })
+    testCooperationId = testCooperation.insertedId
+  })
+
+  afterEach(async () => {
+    await database.dropDatabase()
+  })
+
+  afterAll(async () => {
+    await client.close()
+  })
+
+  it('should migrate up', async () => {
+    await up(database)
+
+    const cooperationData = await database.collection(COOPERATIONS).findOne({ _id: testCooperationId })
+
+    expect(cooperationData.category.toString()).toBe(testCategoryId.toString())
+    expect(cooperationData.subject.toString()).toBe(testSubjectId.toString())
+    expect(cooperationData.proficiencyLevel).toEqual(expect.arrayContaining(testOfferData.proficiencyLevel))
+    expect(cooperationData.description).toBe(testOfferData.description)
+    expect(cooperationData.languages).toEqual(expect.arrayContaining(testOfferData.languages))
+  })
+
+  it('should migrate down', async () => {
+    await up(database)
+    await down(database)
+
+    const cooperationData = await database.collection(COOPERATIONS).findOne({ _id: testCooperationId })
+
+    expect(cooperationData.category).toBeUndefined()
+    expect(cooperationData.subject).toBeUndefined()
+    expect(cooperationData.proficiencyLevel).toEqual(testOfferData.proficiencyLevel[0])
+    expect(cooperationData.description).toBeUndefined()
+    expect(cooperationData.languages).toBeUndefined()
+  })
+})

--- a/src/test/migrations/20250114092340-remove-offers-with-non-existing-author.spec.js
+++ b/src/test/migrations/20250114092340-remove-offers-with-non-existing-author.spec.js
@@ -4,6 +4,7 @@ const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
 const Offer = require('~/models/offer')
 const Cooperation = require('~/models/cooperation')
 const migration = require('@root/migrations/20250114092340-remove-offers-with-non-existing-author')
+const { testCooperationData: cooperationData } = require('~/test/test-constants')
 
 const offerData = {
   price: 500,
@@ -19,30 +20,12 @@ const offerData = {
   status: 'active'
 }
 
-const cooperationData = {
-  offer: '6739b6993decba1e46b66a26',
-  initiator: '5f5f5f5f5f5f5f5f5f5f5f5f',
-  initiatorRole: 'student',
-  receiver: '673615d36b214652201af558',
-  receiverRole: 'tutor',
-  title: 'The 12 Principles of Animation',
-  proficiencyLevel: 'Beginner',
-  price: 500,
-  status: 'active',
-  needAction: {
-    role: 'tutor',
-    type: 'price',
-    messages: []
-  },
-  availableQuizzes: [],
-  finishedQuizzes: [],
-  sections: []
-}
-
 const userData = {
   email: 'john_doe@example.com',
   password: 'password'
 }
+
+console.log('cooperationData', cooperationData)
 
 const notValidAuthorId = '5f5f5f5f5f5f5f5f5f5f5f5f'
 

--- a/src/test/migrations/20250124143502-remove-cooperations-with-invalid-references.spec.js
+++ b/src/test/migrations/20250124143502-remove-cooperations-with-invalid-references.spec.js
@@ -1,25 +1,9 @@
 const mongoose = require('mongoose')
 const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
 const Cooperation = require('~/models/cooperation')
+const { testCooperationData: cooperation } = require('~/test/test-constants')
 
 const migration = require('@root/migrations/20250124143502-remove-cooperations-with-invalid-references')
-
-const cooperation = {
-  initiatorRole: 'student',
-  receiverRole: 'tutor',
-  title: 'Hawking radiation from supermassive black holes',
-  price: 300,
-  status: 'active',
-  needAction: {
-    role: 'student',
-    type: 'price',
-    messages: []
-  },
-  availableQuizzes: [],
-  finishedQuizzes: [],
-  sections: [],
-  proficiencyLevel: 'Intermediate'
-}
 
 const initiatorData = {
   email: 'john_doe@example.com',

--- a/src/test/migrations/20250125172611-update-cooperations-additional-info-length.spec.js
+++ b/src/test/migrations/20250125172611-update-cooperations-additional-info-length.spec.js
@@ -1,27 +1,9 @@
 const mongoose = require('mongoose')
 const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
 const Cooperation = require('~/models/cooperation')
+const { testCooperationData: cooperationData } = require('~/test/test-constants')
 
 const migration = require('@root/migrations/20250125172611-update-cooperations-additional-info-length')
-
-const cooperationData = {
-  offer: '6739b6993decba1e46b66a26',
-  initiator: '5f5f5f5f5f5f5f5f5f5f5f5f',
-  initiatorRole: 'student',
-  receiver: '673615d36b214652201af558',
-  receiverRole: 'tutor',
-  proficiencyLevel: 'Beginner',
-  price: 500,
-  status: 'active',
-  needAction: {
-    role: 'student',
-    type: 'price',
-    messages: []
-  },
-  availableQuizzes: [],
-  finishedQuizzes: [],
-  sections: []
-}
 
 const validCooperation = {
   ...cooperationData,

--- a/src/test/test-constants.js
+++ b/src/test/test-constants.js
@@ -1,0 +1,63 @@
+const {
+  enums: { RESOURCES_TYPES_ENUM }
+} = require('~/consts/validation')
+
+const collectionNames = {
+  SUBJECTS: 'subjects',
+  CATEGORIES: 'categories',
+  OFFERS: 'offers',
+  COOPERATIONS: 'cooperation'
+}
+
+const testCategoryData = {
+  name: 'IT',
+  appearance: {
+    icon: 'AccountTreeRoundedIcon',
+    color: '#47B8B8'
+  }
+}
+
+const testCooperationData = {
+  price: 400,
+  offer: '6750caa8466f194485b1e19a',
+  receiver: '6750ca3f466f194485b1e178',
+  receiverRole: 'tutor',
+  initiator: '6736f6cec333d2e67f3710dc',
+  initiatorRole: 'student',
+  proficiencyLevel: ['Beginner'],
+  title: 'Test cooperation title',
+  description: 'Some description...',
+  subject: '6502ec2060ec37be943353e2',
+  category: '64884fedfdc2d1a130c24ade',
+  languages: ['English'],
+  needAction: {
+    role: 'tutor',
+    type: 'price',
+    messages: []
+  },
+  sections: [
+    {
+      title: 'Section 1',
+      description: 'Section 1 description',
+      resources: [
+        {
+          resource: {
+            _id: '6684179479e5232bce4579fa',
+            author: '6658f73f93885febb491e08b',
+            content: '<p><strong>Solving Quadratic Equations Using the Quadratic Formula</strong></p>',
+            description: 'The quadratic formula',
+            title: 'Solving Quadratic Equations Using the Quadratic Formula',
+            category: '6684175179e5232bce4579ed',
+            resourceType: RESOURCES_TYPES_ENUM[0]
+          },
+          resourceType: RESOURCES_TYPES_ENUM[0],
+          availability: { status: 'open', date: null }
+        }
+      ]
+    }
+  ]
+}
+
+const testSubjectData = { name: 'Web Development' }
+
+module.exports = { testCategoryData, testSubjectData, testCooperationData, collectionNames }

--- a/src/test/test-utils.js
+++ b/src/test/test-utils.js
@@ -2,6 +2,7 @@ const testUserAuthentication = require('~/utils/testUserAuth')
 const TokenService = require('~/services/token')
 const checkCategoryExistence = require('~/seed/checkCategoryExistence')
 const Category = require('~/models/category')
+
 const createUser = async (app, testUser = {}) => {
   const accessToken = await testUserAuthentication(app, testUser)
   const decodedToken = TokenService.validateAccessToken(accessToken)

--- a/src/utils/cooperations/coopsAggregateOptions.js
+++ b/src/utils/cooperations/coopsAggregateOptions.js
@@ -65,31 +65,32 @@ const coopsAggregateOptions = (query, params = {}) => {
     },
     {
       $lookup: {
-        from: 'offers',
-        localField: 'offer',
+        from: 'subjects',
+        localField: 'subject',
         foreignField: '_id',
         pipeline: [
-          { $project: { title: 1, subject: 1, category: 1, price: 1 } },
           {
-            $lookup: {
-              from: 'subjects',
-              let: { subjectId: '$subject' },
-              pipeline: [{ $match: { $expr: { $eq: ['$_id', '$$subjectId'] } } }, { $project: { name: 1 } }],
-              as: 'subject'
+            $project: {
+              name: 1
             }
-          },
-          {
-            $lookup: {
-              from: 'categories',
-              let: { categoryId: '$category' },
-              pipeline: [{ $match: { $expr: { $eq: ['$_id', '$$categoryId'] } } }, { $project: { appearance: 1 } }],
-              as: 'category'
-            }
-          },
-          { $unwind: '$subject' },
-          { $unwind: '$category' }
+          }
         ],
-        as: 'offer'
+        as: 'subject'
+      }
+    },
+    {
+      $lookup: {
+        from: 'categories',
+        localField: 'category',
+        foreignField: '_id',
+        pipeline: [
+          {
+            $project: {
+              appearance: 1
+            }
+          }
+        ],
+        as: 'category'
       }
     },
     {
@@ -97,11 +98,8 @@ const coopsAggregateOptions = (query, params = {}) => {
         path: '$user'
       }
     },
-    {
-      $unwind: {
-        path: '$offer'
-      }
-    },
+    { $unwind: '$category' },
+    { $unwind: '$subject' },
     {
       $unset: 'sections'
     },

--- a/src/utils/cooperations/getCooperationByIdQueryPipeline.js
+++ b/src/utils/cooperations/getCooperationByIdQueryPipeline.js
@@ -299,74 +299,7 @@ const getCooperationByIdQueryPipeline = (id, isClosedResourcesHidden, userId) =>
         from: 'offers',
         localField: 'offer',
         foreignField: '_id',
-        as: 'offer',
-        pipeline: [
-          {
-            $lookup: {
-              from: 'categories',
-              localField: 'category',
-              foreignField: '_id',
-              as: 'category'
-            }
-          },
-          {
-            $lookup: {
-              from: 'users',
-              localField: 'author',
-              foreignField: '_id',
-              as: 'author'
-            }
-          },
-          {
-            $lookup: {
-              from: 'subjects',
-              localField: 'subject',
-              foreignField: '_id',
-              as: 'subject'
-            }
-          },
-          {
-            $set: {
-              author: {
-                $first: '$author'
-              },
-              category: {
-                $first: '$category'
-              },
-              subject: {
-                $first: '$subject'
-              }
-            }
-          },
-          {
-            $project: {
-              _id: true,
-              author: {
-                _id: true,
-                firstName: true,
-                lastName: true,
-                photo: true,
-                professionalSummary: true,
-                totalReviews: true,
-                FAQ: true,
-                averageRating: true
-              },
-              category: {
-                _id: true,
-                name: true,
-                appearance: true
-              },
-              subject: {
-                _id: true,
-                name: true
-              },
-              title: true,
-              languages: true,
-              proficiencyLevel: true,
-              description: true
-            }
-          }
-        ]
+        as: 'offer'
       }
     },
     {
@@ -378,7 +311,7 @@ const getCooperationByIdQueryPipeline = (id, isClosedResourcesHidden, userId) =>
           $first: '$receiver'
         },
         offer: {
-          $first: '$offer'
+          $first: '$offer._id'
         }
       }
     },


### PR DESCRIPTION
Copied `subject`, `category`, `description`, `languages` and `proficiencyLevel` from offers and added them to cooperations so that changes in offers don't affect cooperation data.

The responses from `getCooperationById` and `getCooperations` have been changed: `category` and `subject` were added, but they were removed from `response.offer`. The response also contains `title`, `price` and `languages`. The field `proficiencyLevel` is an array of strings in the response .

The data for `createCooperation` has been changed: `subject`, `category`, `description` and `languages` are required to create a cooperation.

**Important information:
After merging this PR, change `mongodb.url` in the `migrate-mongo-config.js` file and paste the remote database url, run the command `npx migrate-mongo up`. After that, check that fields `subject`, `category`, `description`, `languages` and `proficiencyLevel` have been copied from offers to cooperations in the remote database. Change `mongodb.url` to the local database url.**