### PR TITLE
Fix swagger docs error POST /lessons

### DIFF
--- a/docs/lesson/lesson.yaml
+++ b/docs/lesson/lesson.yaml
@@ -101,7 +101,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#definitions/lessons'
+                $ref: '#/definitions/lesson'
               example:
                 title: Colors in English
                 description: With this lesson you will learn all about colors in English.


### PR DESCRIPTION
Updated Swagger Documentation for `/lessons` POST Method