### PR TITLE
Сhanged import order in course tests

### DIFF
--- a/src/test/integration/controllers/course.spec.js
+++ b/src/test/integration/controllers/course.spec.js
@@ -1,8 +1,8 @@
 const Course = require('~/models/course')
 
+const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
 const uploadService = require('~/services/upload')
 const { expectError } = require('~/test/helpers')
-const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
 const checkCategoryExistence = require('~/seed/checkCategoryExistence')
 const testUserAuthentication = require('~/utils/testUserAuth')
 


### PR DESCRIPTION
Swapping the import order of serverInit and uploadService resolved the issue because serverInit likely performs critical setup needed by uploadService or other parts of the test environment

![image](https://github.com/user-attachments/assets/f7ed4625-046f-49f3-a01d-b637035555aa)
