### PR TITLE
Fix swagger docs error POST /lessons | /components/attachments

### DIFF
--- a/docs/lesson/lesson-schema.yaml
+++ b/docs/lesson/lesson-schema.yaml
@@ -22,7 +22,7 @@ definitions:
         maxLength: 1000
       attachments:
         type: array
-        $ref: '#/components/attachments'
+        $ref: '#/definitions/attachments'
       category:
         type: string
         $ref: '#/definitions/resourcesCategory'
@@ -45,7 +45,7 @@ definitions:
         type: string
       attachments:
         type: array
-        $ref: '#/components/attachments'
+        $ref: '#/definitions/attachments'
       category:
         type: string
         $ref: '#/definitions/resourcesCategory'


### PR DESCRIPTION
Updated references to lesson and lesson body attachments in Swagger documentation to resolve POST /lessons | /components/attachments errors.