### PR TITLE
Add a status field for resources in cooperation model

### DIFF
--- a/docs/cooperation/cooperation-schema.yaml
+++ b/docs/cooperation/cooperation-schema.yaml
@@ -10,19 +10,32 @@ definitions:
           type: string
           ref: '#components/offer'
         initiator:
-          type: string
-          ref: '#/components/user'
+          type: object
+          $ref: '#/definitions/cooperationUser'
         initiatorRole:
           type: string
         receiver:
-          type: string
-          ref: '#components/user'
+          type: object
+          $ref: '#/definitions/cooperationUser'
         receiverRole:
           type: string
         price:
           type: number
         title:
           type: string
+        additionalInfo:
+          type: string
+          minLength: 30
+          maxLength: 1000
+        proficiencyLevel:
+          type: string
+          enum:
+            - Beginner
+            - Intermediate
+            - Advanced
+            - Test Preparation
+            - Professional
+            - Specialized
         status:
           type: string
           enum:
@@ -40,59 +53,25 @@ definitions:
           items:
             type: string
             ref: '#components/finishedQuiz'
-        sections:
-          type: array
-          items:
-            type: object
-            properties:
-              title:
-                type: string
-              description:
-                type: string
-              resources:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    resource:
-                      type: object
-                      additionalProperties: true
-                    resourceType:
-                      type: string
-                      enum:
-                        - lesson
-                        - quiz
-                        - attachment
-                    availability:
-                      type: object
-                      properties:
-                        status:
-                          type: string
-                          enum:
-                            - open
-                            - closed
-                            - openFrom
-                          default: open
-                        date:
-                          type: string
-                          format: date-time
-                          default: null
-                    completionStatus:
-                      type: string
-                      enum:
-                        - active
-                        - completed
         needAction:
           type: string
           enum:
             - student
             - tutor
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
+        user:
+          type: object
+          description: Details of the partner user involved in the cooperation
+          properties:
+            _id:
+              type: string
+            firstName:
+              type: string
+            lastName:
+              type: string
+            photo:
+              type: string
+            role:
+              type: string
   cooperation:
     type: object
     properties:
@@ -102,19 +81,32 @@ definitions:
         type: string
         ref: '#components/offer'
       initiator:
-        type: string
-        ref: '#/components/user'
+        type: object
+        $ref: '#/definitions/cooperationUser'
       initiatorRole:
         type: string
       receiver:
-        type: string
-        ref: '#components/user'
+        type: object
+        $ref: '#/definitions/cooperationUser'
       receiverRole:
         type: string
       price:
         type: number
       title:
         type: string
+      additionalInfo:
+        type: string
+        minLength: 30
+        maxLength: 1000
+      proficiencyLevel:
+        type: string
+        enum:
+          - Beginner
+          - Intermediate
+          - Advanced
+          - Test Preparation
+          - Professional
+          - Specialized
       status:
         type: string
         enum:
@@ -136,44 +128,7 @@ definitions:
         type: array
         items:
           type: object
-          properties:
-            title:
-              type: string
-            description:
-              type: string
-            resources:
-              type: array
-              items:
-                type: object
-                properties:
-                  resource:
-                    type: object
-                    additionalProperties: true
-                  resourceType:
-                    type: string
-                    enum:
-                      - lesson
-                      - quiz
-                      - attachment
-                  availability:
-                    type: object
-                    properties:
-                      status:
-                        type: string
-                        enum:
-                          - open
-                          - closed
-                          - openFrom
-                        default: open
-                      date:
-                        type: string
-                        format: date-time
-                        default: null
-                  completionStatus:
-                    type: string
-                    enum:
-                      - active
-                      - completed
+          $ref: '#/definitions/section'
       needAction:
         type: string
         enum:
@@ -192,383 +147,156 @@ definitions:
         type: string
         ref: '#components/offer'
       receiver:
-        type: string
-        ref: '#components/user'
+        type: object
+        $ref: '#/definitions/cooperationUser'
       receiverRole:
         type: string
       price:
         type: number
-      status:
-        type: string
-        enum:
-          - pending
-          - active
-          - declined
-          - closed
-      sections:
-        type: array
-        items:
-          type: object
-          properties:
-            title:
-              type: string
-            description:
-              type: string
-            resources:
-              type: array
-              items:
-                type: object
-                properties:
-                  resource:
-                    type: object
-                    additionalProperties: true
-                  resourceType:
-                    type: string
-                    enum:
-                      - lesson
-                      - quiz
-                      - attachment
-                  availability:
-                    type: object
-                    properties:
-                      status:
-                        type: string
-                        enum:
-                          - open
-                          - closed
-                          - openFrom
-                        default: open
-                      date:
-                        type: string
-                        format: date-time
-                        default: null
-  cooperationResponse:
-    type: object
-    properties:
-      _id:
-        type: string
-      offer:
-        type: object
-        properties:
-          _id:
-            type: string
-          proficiencyLevel:
-            type: array
-            items:
-              type: string
-          title:
-            type: string
-          description:
-            type: string
-          languages:
-            type: array
-            items:
-              type: string
-          author:
-            type: object
-            properties:
-              totalReviews:
-                type: object
-                properties:
-                  student:
-                    type: integer
-                  tutor:
-                    type: integer
-              averageRating:
-                type: object
-                properties:
-                  student:
-                    type: number
-                  tutor:
-                    type: number
-              _id:
-                type: string
-              firstName:
-                type: string
-              lastName:
-                type: string
-              photo:
-                type: string
-              professionalSummary:
-                type: string
-          subject:
-            type: object
-            properties:
-              _id:
-                type: string
-              name:
-                type: string
-          category:
-            type: object
-            properties:
-              appearance:
-                type: object
-                properties:
-                  color:
-                    type: string
-                  icon:
-                    type: string
-              _id:
-                type: string
-              name:
-                type: string
-      initiator:
-        type: object
-        properties:
-          address:
-            type: object
-            properties:
-              country:
-                type: string
-              city:
-                type: string
-          mainSubjects:
-            type: object
-            properties:
-              student:
-                type: array
-                items:
-                  type: string
-              tutor:
-                type: array
-                items:
-                  type: string
-          totalReviews:
-            type: object
-            properties:
-              student:
-                type: integer
-              tutor:
-                type: integer
-          averageRating:
-            type: object
-            properties:
-              student:
-                type: number
-              tutor:
-                type: number
-          status:
-            type: object
-            properties:
-              student:
-                type: string
-              tutor:
-                type: string
-              admin:
-                type: string
-          videoLink:
-            type: object
-            properties:
-              student:
-                type: string
-          professionalBlock:
-            type: object
-            properties:
-              awards:
-                type: string
-              scientificActivities:
-                type: string
-              workExperience:
-                type: string
-              education:
-                type: string
-          notificationSettings:
-            type: object
-            properties:
-              isOfferStatusNotification:
-                type: boolean
-              isChatNotification:
-                type: boolean
-              isSimilarOffersNotification:
-                type: boolean
-              isEmailNotification:
-                type: boolean
-          _id:
-            type: string
-          role:
-            type: array
-            items:
-              type: string
-          firstName:
-            type: string
-          lastName:
-            type: string
-          email:
-            type: string
-          nativeLanguage:
-            type: string
-          lastLogin:
-            type: string
-          createdAt:
-            type: string
-          updatedAt:
-            type: string
-          professionalSummary:
-            type: string
-      initiatorRole:
-        type: string
-      receiver:
-        type: object
-        properties:
-          address:
-            type: object
-            properties:
-              country:
-                type: string
-              city:
-                type: string
-          mainSubjects:
-            type: object
-            properties:
-              student:
-                type: array
-                items:
-                  type: string
-              tutor:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    category:
-                      type: string
-                    subjects:
-                      type: array
-                      items:
-                        type: string
-                    _id:
-                      type: string
-          totalReviews:
-            type: object
-            properties:
-              student:
-                type: integer
-              tutor:
-                type: integer
-          averageRating:
-            type: object
-            properties:
-              student:
-                type: number
-              tutor:
-                type: number
-          status:
-            type: object
-            properties:
-              student:
-                type: string
-              tutor:
-                type: string
-              admin:
-                type: string
-          videoLink:
-            type: object
-            properties:
-              tutor:
-                type: string
-          professionalBlock:
-            type: object
-            properties:
-              awards:
-                type: string
-              scientificActivities:
-                type: string
-              workExperience:
-                type: string
-              education:
-                type: string
-          notificationSettings:
-            type: object
-            properties:
-              isOfferStatusNotification:
-                type: boolean
-              isChatNotification:
-                type: boolean
-              isSimilarOffersNotification:
-                type: boolean
-              isEmailNotification:
-                type: boolean
-          _id:
-            type: string
-          role:
-            type: array
-            items:
-              type: string
-          firstName:
-            type: string
-          lastName:
-            type: string
-          email:
-            type: string
-          nativeLanguage:
-            type: string
-          lastLogin:
-            type: string
-          createdAt:
-            type: string
-          updatedAt:
-            type: string
-          photo:
-            type: string
-          professionalSummary:
-            type: string
-      receiverRole:
-        type: string
       title:
         type: string
+      additionalInfo:
+        type: string
+        minLength: 30
+        maxLength: 1000
       proficiencyLevel:
         type: string
-      price:
-        type: integer
-      status:
-        type: string
-      needAction:
-        type: string
-      availableQuizzes:
-        type: array
-        items:
-          type: string
-      finishedQuizzes:
-        type: array
-        items:
-          type: string
+        enum:
+          - Beginner
+          - Intermediate
+          - Advanced
+          - Test Preparation
+          - Professional
+          - Specialized
       sections:
         type: array
         items:
           type: object
+          $ref: '#/definitions/section'
+    required:
+      - title
+      - offer
+      - receiver
+      - proficiencyLevel
+      - receiverRole
+      - price
+  section:
+    type: object
+    properties:
+      title:
+        type: string
+      description:
+        type: string
+      resources:
+        type: array
+        items:
+          type: object
           properties:
-            title:
+            resource:
+              type: object
+              additionalProperties: true
+            resourceType:
               type: string
-            description:
+              enum:
+                - lesson
+                - quiz
+                - attachment
+            availability:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - open
+                    - closed
+                    - openFrom
+                  default: open
+                date:
+                  type: string
+                  format: date-time
+                  default: null
+            completionStatus:
               type: string
-            resources:
-              type: array
-              items:
-                type: object
-                properties:
-                  resource:
-                    type: object
-                    additionalProperties: true
-                  resourceType:
+              enum:
+                - active
+                - completed
+  cooperationUser:
+    type: object
+    properties:
+      address:
+        type: object
+        properties:
+          country:
+            type: string
+          city:
+            type: string
+      mainSubjects:
+        type: object
+        properties:
+          student:
+            type: array
+            items:
+              type: string
+          tutor:
+            type: array
+            items:
+              type: object
+              properties:
+                category:
+                  type: string
+                subjects:
+                  type: array
+                  items:
                     type: string
-                    enum:
-                      - lesson
-                      - quiz
-                      - attachment
-                  availability:
-                    type: object
-                    properties:
-                      status:
-                        type: string
-                        enum:
-                          - open
-                          - closed
-                          - openFrom
-                        default: open
-                      date:
-                        type: string
-                        format: date-time
-                        default: null
-      createdAt:
-        type: string
-      updatedAt:
-        type: string
+                _id:
+                  type: string
+      totalReviews:
+        type: object
+        properties:
+          student:
+            type: integer
+          tutor:
+            type: integer
+      averageRating:
+        type: object
+        properties:
+          student:
+            type: number
+          tutor:
+            type: number
+      status:
+        type: object
+        properties:
+          student:
+            type: string
+          tutor:
+            type: string
+          admin:
+            type: string
+      videoLink:
+        type: object
+        properties:
+          tutor:
+            type: string
+      professionalBlock:
+        type: object
+        properties:
+          awards:
+            type: string
+          scientificActivities:
+            type: string
+          workExperience:
+            type: string
+          education:
+            type: string
+      notificationSettings:
+        type: object
+        properties:
+          isOfferStatusNotification:
+            type: boolean
+          isChatNotification:
+            type: boolean
+          isSimilarOffersNotification:
+            type: boolean
+          isEmailNotification:
+            type: boolean

--- a/docs/cooperation/cooperation-schema.yaml
+++ b/docs/cooperation/cooperation-schema.yaml
@@ -133,9 +133,13 @@ definitions:
     type: object
     properties:
       offer:
-        $ref: '#/definitions/offer'
+        type: string
+        description: _id
+        ref: '#/definitions/offer'
       receiver:
-        $ref: '#/definitions/user'
+        type: string
+        description: _id
+        ref: '#/definitions/user'
       receiverRole:
         type: string
       price:

--- a/docs/cooperation/cooperation-schema.yaml
+++ b/docs/cooperation/cooperation-schema.yaml
@@ -30,6 +30,16 @@ definitions:
             - active
             - declined
             - closed
+        availableQuizzes:
+          type: array
+          items:
+            type: string
+            ref: '#components/quiz'
+        finishedQuizzes:
+          type: array
+          items:
+            type: string
+            ref: '#components/finishedQuiz'
         sections:
           type: array
           items:
@@ -112,6 +122,16 @@ definitions:
           - active
           - declined
           - closed
+      availableQuizzes:
+        type: array
+        items:
+          type: string
+          ref: '#components/quiz'
+      finishedQuizzes:
+        type: array
+        items:
+          type: string
+          ref: '#components/finishedQuiz'
       sections:
         type: array
         items:

--- a/docs/cooperation/cooperation-schema.yaml
+++ b/docs/cooperation/cooperation-schema.yaml
@@ -7,15 +7,12 @@ definitions:
         _id:
           type: string
         offer:
-          type: string
-          ref: '#components/offer'
+          $ref: '#/definitions/offer'
         initiator:
-          type: object
           $ref: '#/definitions/cooperationUser'
         initiatorRole:
           type: string
         receiver:
-          type: object
           $ref: '#/definitions/cooperationUser'
         receiverRole:
           type: string
@@ -46,13 +43,11 @@ definitions:
         availableQuizzes:
           type: array
           items:
-            type: string
-            ref: '#components/quiz'
+            $ref: '#/definitions/quiz'
         finishedQuizzes:
           type: array
           items:
-            type: string
-            ref: '#components/finishedQuiz'
+            $ref: '#/definitions/finishedQuiz'
         needAction:
           type: string
           enum:
@@ -78,15 +73,12 @@ definitions:
       _id:
         type: string
       offer:
-        type: string
-        ref: '#components/offer'
+        $ref: '#/definitions/offer'
       initiator:
-        type: object
         $ref: '#/definitions/cooperationUser'
       initiatorRole:
         type: string
       receiver:
-        type: object
         $ref: '#/definitions/cooperationUser'
       receiverRole:
         type: string
@@ -117,17 +109,14 @@ definitions:
       availableQuizzes:
         type: array
         items:
-          type: string
-          ref: '#components/quiz'
+          $ref: '#/definitions/quiz'
       finishedQuizzes:
         type: array
         items:
-          type: string
-          ref: '#components/finishedQuiz'
+          $ref: '#/definitions/finishedQuiz'
       sections:
         type: array
         items:
-          type: object
           $ref: '#/definitions/section'
       needAction:
         type: string
@@ -144,10 +133,8 @@ definitions:
     type: object
     properties:
       offer:
-        type: string
-        ref: '#components/offer'
+        $ref: '#/definitions/offer'
       receiver:
-        type: object
         $ref: '#/definitions/cooperationUser'
       receiverRole:
         type: string
@@ -171,7 +158,6 @@ definitions:
       sections:
         type: array
         items:
-          type: object
           $ref: '#/definitions/section'
     required:
       - title

--- a/docs/cooperation/cooperation-schema.yaml
+++ b/docs/cooperation/cooperation-schema.yaml
@@ -30,6 +30,48 @@ definitions:
             - active
             - declined
             - closed
+        sections:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              description:
+                type: string
+              resources:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    resource:
+                      type: object
+                      additionalProperties: true
+                    resourceType:
+                      type: string
+                      enum:
+                        - lesson
+                        - quiz
+                        - attachment
+                    availability:
+                      type: object
+                      properties:
+                        status:
+                          type: string
+                          enum:
+                            - open
+                            - closed
+                            - openFrom
+                          default: open
+                        date:
+                          type: string
+                          format: date-time
+                          default: null
+                    completionStatus:
+                      type: string
+                      enum:
+                        - active
+                        - completed
         needAction:
           type: string
           enum:
@@ -107,6 +149,11 @@ definitions:
                         type: string
                         format: date-time
                         default: null
+                  completionStatus:
+                    type: string
+                    enum:
+                      - active
+                      - completed
       needAction:
         type: string
         enum:

--- a/docs/cooperation/cooperation-schema.yaml
+++ b/docs/cooperation/cooperation-schema.yaml
@@ -9,11 +9,11 @@ definitions:
         offer:
           $ref: '#/definitions/offer'
         initiator:
-          $ref: '#/definitions/cooperationUser'
+          $ref: '#/definitions/user'
         initiatorRole:
           type: string
         receiver:
-          $ref: '#/definitions/cooperationUser'
+          $ref: '#/definitions/user'
         receiverRole:
           type: string
         price:
@@ -75,11 +75,11 @@ definitions:
       offer:
         $ref: '#/definitions/offer'
       initiator:
-        $ref: '#/definitions/cooperationUser'
+        $ref: '#/definitions/user'
       initiatorRole:
         type: string
       receiver:
-        $ref: '#/definitions/cooperationUser'
+        $ref: '#/definitions/user'
       receiverRole:
         type: string
       price:
@@ -135,7 +135,7 @@ definitions:
       offer:
         $ref: '#/definitions/offer'
       receiver:
-        $ref: '#/definitions/cooperationUser'
+        $ref: '#/definitions/user'
       receiverRole:
         type: string
       price:
@@ -206,83 +206,3 @@ definitions:
               enum:
                 - active
                 - completed
-  cooperationUser:
-    type: object
-    properties:
-      address:
-        type: object
-        properties:
-          country:
-            type: string
-          city:
-            type: string
-      mainSubjects:
-        type: object
-        properties:
-          student:
-            type: array
-            items:
-              type: string
-          tutor:
-            type: array
-            items:
-              type: object
-              properties:
-                category:
-                  type: string
-                subjects:
-                  type: array
-                  items:
-                    type: string
-                _id:
-                  type: string
-      totalReviews:
-        type: object
-        properties:
-          student:
-            type: integer
-          tutor:
-            type: integer
-      averageRating:
-        type: object
-        properties:
-          student:
-            type: number
-          tutor:
-            type: number
-      status:
-        type: object
-        properties:
-          student:
-            type: string
-          tutor:
-            type: string
-          admin:
-            type: string
-      videoLink:
-        type: object
-        properties:
-          tutor:
-            type: string
-      professionalBlock:
-        type: object
-        properties:
-          awards:
-            type: string
-          scientificActivities:
-            type: string
-          workExperience:
-            type: string
-          education:
-            type: string
-      notificationSettings:
-        type: object
-        properties:
-          isOfferStatusNotification:
-            type: boolean
-          isChatNotification:
-            type: boolean
-          isSimilarOffersNotification:
-            type: boolean
-          isEmailNotification:
-            type: boolean

--- a/docs/cooperation/cooperation.yaml
+++ b/docs/cooperation/cooperation.yaml
@@ -30,7 +30,12 @@ paths:
                   needAction: student
                   availableQuizzes: []
                   finishedQuizzes: []
-                  sections: []
+                  user:
+                    _id: '6255bc080a75adf9223df100'
+                    firstName: 'Emily'
+                    lastName: 'Jhonson'
+                    photo: ''
+                    role: 'student'
                   createdAt: 2021-05-09T11:34:53.243+00:00
                   updatedAt: 2022-07-02T11:59:53.243+00:00
                 - _id: 63ebc6fbd2f34037d0aba314
@@ -46,7 +51,12 @@ paths:
                   needAction: tutor
                   availableQuizzes: []
                   finishedQuizzes: []
-                  sections: []
+                  user:
+                    _id: '6255bc080a75adf9223df100'
+                    firstName: 'Emily'
+                    lastName: 'Jhonson'
+                    photo: ''
+                    role: 'student'
                   createdAt: 2021-04-09T11:34:53.243+00:00
                   updatedAt: 2022-09-02T11:59:53.243+00:00
         401:
@@ -74,8 +84,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/cooperation'
+              $ref: '#/definitions/cooperationBody'
             example:
+              title: Violin lessons
+              proficiencyLevel: Test Preparation
               offer: 63ebc6fbd2f34037d0aba791
               receiver: 6255bc080a75adf9223df100
               receiverRole: student
@@ -147,7 +159,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/cooperationResponse'
+                $ref: '#/definitions/cooperation'
               example:
                 _id: 8755bc080a00adr9243df106
                 offer:

--- a/docs/quiz/quiz-schema.yaml
+++ b/docs/quiz/quiz-schema.yaml
@@ -48,11 +48,15 @@ definitions:
       description:
         type: string
       category:
-        $ref: '#/definitions/resourcesCategory'
+        type: string
+        description: _id
+        ref: '#/definitions/resourcesCategory'
       items:
         type: array
         items:
-          $ref: '#/definitions/question'
+          type: string
+          description: _id
+          ref: '#/components/question'
       settings:
         type: object
         properties:

--- a/docs/quiz/quiz-schema.yaml
+++ b/docs/quiz/quiz-schema.yaml
@@ -15,7 +15,7 @@ definitions:
           items:
             $ref: '#/definitions/question'
         author:
-          $ref: '#/components/user'
+          $ref: '#/definitions/user'
         category:
           $ref: '#/definitions/resourcesCategory'
         settings:

--- a/docs/quiz/quiz-schema.yaml
+++ b/docs/quiz/quiz-schema.yaml
@@ -8,32 +8,31 @@ definitions:
           type: string
         title:
           type: string
-        description: 
+        description:
           type: string
         items:
           type: array
-          $ref: '#/components/question'
+          items:
+            $ref: '#/definitions/question'
         author:
-          type: string
           $ref: '#/components/user'
         category:
-          type: string
           $ref: '#/definitions/resourcesCategory'
-        settings: 
+        settings:
           type: object
-          properties: 
+          properties:
             view:
               type: string
-              enum: 
+              enum:
                 - Stepper
                 - Scroll
             shuffle:
               type: boolean
             pointValues:
               type: boolean
-            scoredResponses: 
+            scoredResponses:
               type: boolean
-            correctAnswers: 
+            correctAnswers:
               type: boolean
         createdAt:
           type: string
@@ -46,30 +45,30 @@ definitions:
     properties:
       title:
         type: string
-      description: 
+      description:
         type: string
       category:
-        type: string
         $ref: '#/definitions/resourcesCategory'
       items:
         type: array
-        $ref: '#/components/question'
-      settings: 
-          type: object
-          properties: 
-            view:
-              type: string
-              enum: 
-                - Stepper
-                - Scroll
-            shuffle:
-              type: boolean
-            pointValues:
-              type: boolean
-            scoredResponses: 
-              type: boolean
-            correctAnswers: 
-              type: boolean
+        items:
+          $ref: '#/definitions/question'
+      settings:
+        type: object
+        properties:
+          view:
+            type: string
+            enum:
+              - Stepper
+              - Scroll
+          shuffle:
+            type: boolean
+          pointValues:
+            type: boolean
+          scoredResponses:
+            type: boolean
+          correctAnswers:
+            type: boolean
   quiz:
     type: object
     properties:
@@ -77,37 +76,35 @@ definitions:
         type: string
       title:
         type: string
-      description: 
+      description:
         type: string
       items:
         type: array
-        $ref: '#/components/question'
+        items:
+          $ref: '#/definitions/question'
       author:
-        type: string
-        $ref: '#/components/user'
+        $ref: '#/definitions/user'
       category:
-        type: string
         $ref: '#/definitions/resourcesCategory'
-      settings: 
-          type: object
-          properties: 
-            view:
-              type: string
-              enum: 
-                - Stepper
-                - Scroll
-            shuffle:
-              type: boolean
-            pointValues:
-              type: boolean
-            scoredResponses: 
-              type: boolean
-            correctAnswers: 
-              type: boolean
+      settings:
+        type: object
+        properties:
+          view:
+            type: string
+            enum:
+              - Stepper
+              - Scroll
+          shuffle:
+            type: boolean
+          pointValues:
+            type: boolean
+          scoredResponses:
+            type: boolean
+          correctAnswers:
+            type: boolean
       createdAt:
         type: string
         format: date-time
       updatedAt:
         type: string
         format: date-time
-        

--- a/docs/user/user-schema.yaml
+++ b/docs/user/user-schema.yaml
@@ -221,8 +221,17 @@ definitions:
             type: number
       nativeLanguage:
         type: string
-      notificatoinSettings:
-
+      notificationSettings:
+        type: object
+        properties:
+          isOfferStatusNotification:
+            type: boolean
+          isChatNotification:
+            type: boolean
+          isSimilarOffersNotification:
+            type: boolean
+          isEmailNotification:
+            type: boolean
       address:
         type: object
         properties:

--- a/src/consts/validation.js
+++ b/src/consts/validation.js
@@ -29,6 +29,7 @@ const enums = {
   QUIZ_SETTINGS_ENUM: ['view', 'shuffle', 'pointValues', 'scoredResponses', 'correctAnswers'],
   RESOURCE_STATUS_ENUM: ['available', 'finished'],
   RESOURCE_AVAILABILITY_STATUS_ENUM: ['open', 'closed', 'openFrom'],
+  RESOURCE_COMPLETION_STATUS_ENUM: ['active', 'completed'],
   RESOURCES_TYPES_ENUM: ['lesson', 'quiz', 'attachment', 'question']
 }
 

--- a/src/models/cooperation.js
+++ b/src/models/cooperation.js
@@ -14,7 +14,8 @@ const {
     PROFICIENCY_LEVEL_ENUM,
     MAIN_ROLE_ENUM,
     RESOURCES_TYPES_ENUM,
-    RESOURCE_AVAILABILITY_STATUS_ENUM
+    RESOURCE_AVAILABILITY_STATUS_ENUM,
+    RESOURCE_COMPLETION_STATUS_ENUM
   }
 } = require('~/consts/validation')
 const { REQUESTED, UPDATED } = require('~/consts/notificationTypes')
@@ -144,6 +145,14 @@ const cooperationSchema = new Schema(
                 type: Date,
                 default: null
               }
+            },
+            completionStatus: {
+              type: String,
+              enum: {
+                values: RESOURCE_COMPLETION_STATUS_ENUM,
+                message: ENUM_CAN_BE_ONE_OF('resource completion status', RESOURCE_COMPLETION_STATUS_ENUM)
+              },
+              default: RESOURCE_COMPLETION_STATUS_ENUM[0]
             }
           }
         ]


### PR DESCRIPTION
### Add  `completionStatus` field 
- Change resources in cooperation model to include a `completionStatus` field (enum: `active` and `completed`), allowing it to be marked as completed by the student/tutor in the future
- Add enum RESOURCE_COMPLETION_STATUS_ENUM

### Update swagger docs to include `completionStatus` field
- extract the `section` definition to reuse it in other definitions, add completionStatus to it
Previews:
cooperationBody [POST /cooperations body screenshot](https://github.com/user-attachments/assets/095914d9-9e33-4122-8d8c-67b6fbd9e2cb)
 coopeartion [GET /coopeartion/{id} response 200 screenshot](https://github.com/user-attachments/assets/3dd3671d-4d44-421c-be60-8b59ed99709c)

#### Update docs for cooperations to include only up-to-date fields:
- cooperations definition: add user (partner of current user) to items as server answer returns the user [POST /cooperations 200 screenshot](https://github.com/user-attachments/assets/989965a1-1c0b-4ff5-a8ed-e9b5796c9b29)
- add missing field in coopeartion definitions - `additionalInfo`  [screenshot](https://github.com/user-attachments/assets/46d1e4d8-0d79-45d7-9234-3143b10a4be2)
- remove `cooperationResponse` as it returns the same response as `cooperation`
- fix $refs to lead to actual definitions (to user, offer, quiz, finishedQuiz)
- fix quiz and user schemas to reference them in cooperations definitions without them causing errors