### PR TITLE
 Fix server error for invalid role parameter in /users/{id}

### DIFF
--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -341,6 +341,16 @@ paths:
                 status: 404
                 code: 'DOCUMENT_NOT_FOUND'
                 message: 'User with the specified id was not found.'
+        422:
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/Error'
+              example:
+                status: 422
+                code: 'FIELD_IS_NOT_OF_PROPER_ENUM_VALUE'
+                message: 'role should be either one of the values: [student, tutor].'
     patch:
       security:
         - cookieAuth: []

--- a/src/consts/requestDataSource.js
+++ b/src/consts/requestDataSource.js
@@ -1,0 +1,6 @@
+const requestDataSource = {
+  BODY: 'body',
+  QUERY: 'query'
+}
+
+module.exports = requestDataSource

--- a/src/consts/requestDataSources.js
+++ b/src/consts/requestDataSources.js
@@ -1,6 +1,0 @@
-const requestDataSources = {
-  BODY: 'body',
-  QUERY: 'query'
-}
-
-module.exports = requestDataSources

--- a/src/consts/requestDataSources.js
+++ b/src/consts/requestDataSources.js
@@ -1,0 +1,6 @@
+const requestDataSources = {
+  BODY: 'body',
+  QUERY: 'query'
+}
+
+module.exports = requestDataSources

--- a/src/middlewares/validation.js
+++ b/src/middlewares/validation.js
@@ -5,14 +5,14 @@ const requestDataSource = require('~/consts/requestDataSource')
 
 const validationMiddleware = (schema, source = requestDataSource.BODY) => {
   return (req, _res, next) => {
-    const data = req[source]
-
-    if (!data && source === requestDataSource.body) {
+    if (source === requestDataSource.BODY && !req[source]) {
       throw createError(422, BODY_IS_NOT_DEFINED)
     }
 
+    const data = req[source]
+
     Object.entries(schema).forEach(([schemaFieldKey, schemaFieldValue]) => {
-      const reqSourceField = data[schemaFieldKey]
+      const reqSourceField = data?.[schemaFieldKey]
       validateRequired(schemaFieldKey, schemaFieldValue?.required, reqSourceField)
       if (reqSourceField) {
         Object.entries(schemaFieldValue).forEach(([validationType, validationValue]) => {

--- a/src/middlewares/validation.js
+++ b/src/middlewares/validation.js
@@ -1,20 +1,22 @@
 const { createError } = require('~/utils/errorsHelper')
 const { BODY_IS_NOT_DEFINED } = require('~/consts/errors')
 const { validateRequired, validateFunc } = require('~/utils/validationHelper')
+const requestDataSources = require('~/consts/requestDataSources')
 
-const validationMiddleware = (schema) => {
+const validationMiddleware = (schema, source = requestDataSources.BODY) => {
   return (req, _res, next) => {
-    const { body } = req
-    if (!body) {
+    const data = req[source]
+
+    if (!data && source === requestDataSources.body) {
       throw createError(422, BODY_IS_NOT_DEFINED)
     }
 
     Object.entries(schema).forEach(([schemaFieldKey, schemaFieldValue]) => {
-      const reqBodyField = body[schemaFieldKey]
-      validateRequired(schemaFieldKey, schemaFieldValue?.required, reqBodyField)
-      if (reqBodyField) {
+      const reqSourceField = data[schemaFieldKey]
+      validateRequired(schemaFieldKey, schemaFieldValue?.required, reqSourceField)
+      if (reqSourceField) {
         Object.entries(schemaFieldValue).forEach(([validationType, validationValue]) => {
-          validateFunc[validationType](schemaFieldKey, validationValue, reqBodyField)
+          validateFunc[validationType](schemaFieldKey, validationValue, reqSourceField)
         })
       }
     })

--- a/src/middlewares/validation.js
+++ b/src/middlewares/validation.js
@@ -1,13 +1,13 @@
 const { createError } = require('~/utils/errorsHelper')
 const { BODY_IS_NOT_DEFINED } = require('~/consts/errors')
 const { validateRequired, validateFunc } = require('~/utils/validationHelper')
-const requestDataSources = require('~/consts/requestDataSources')
+const requestDataSource = require('~/consts/requestDataSource')
 
-const validationMiddleware = (schema, source = requestDataSources.BODY) => {
+const validationMiddleware = (schema, source = requestDataSource.BODY) => {
   return (req, _res, next) => {
     const data = req[source]
 
-    if (!data && source === requestDataSources.body) {
+    if (!data && source === requestDataSource.body) {
       throw createError(422, BODY_IS_NOT_DEFINED)
     }
 

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -15,7 +15,7 @@ const {
   roles: { ADMIN }
 } = require('~/consts/auth')
 const getUserByIdValidationSchema = require('~/validation/schemas/getUserById')
-const requestDataSources = require('~/consts/requestDataSources')
+const requestDataSource = require('~/consts/requestDataSource')
 
 const params = [{ model: User, idName: 'id' }]
 
@@ -32,7 +32,7 @@ router.get('/', asyncWrapper(userController.getUsers))
 router.get(
   '/:id',
   isEntityValid({ params }),
-  validationMiddleware(getUserByIdValidationSchema, requestDataSources.QUERY),
+  validationMiddleware(getUserByIdValidationSchema, requestDataSource.QUERY),
   asyncWrapper(userController.getUserById)
 )
 router.get('/:id/bookmarks/offers', isEntityValid({ params }), asyncWrapper(userController.getBookmarkedOffers))

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -4,6 +4,7 @@ const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
 const { restrictTo, authMiddleware } = require('~/middlewares/auth')
 const isEntityValid = require('~/middlewares/entityValidation')
+const validationMiddleware = require('~/middlewares/validation')
 
 const userController = require('~/controllers/user')
 const reviewRouter = require('~/routes/review')
@@ -13,6 +14,8 @@ const User = require('~/models/user')
 const {
   roles: { ADMIN }
 } = require('~/consts/auth')
+const getUserByIdValidationSchema = require('~/validation/schemas/getUserById')
+const requestDataSources = require('~/consts/requestDataSources')
 
 const params = [{ model: User, idName: 'id' }]
 
@@ -26,7 +29,12 @@ router.use('/:id/cooperations', isEntityValid({ params }), cooperationRouter)
 router.use('/:id/offers', isEntityValid({ params }), offerRouter)
 
 router.get('/', asyncWrapper(userController.getUsers))
-router.get('/:id', isEntityValid({ params }), asyncWrapper(userController.getUserById))
+router.get(
+  '/:id',
+  isEntityValid({ params }),
+  validationMiddleware(getUserByIdValidationSchema, requestDataSources.QUERY),
+  asyncWrapper(userController.getUserById)
+)
 router.get('/:id/bookmarks/offers', isEntityValid({ params }), asyncWrapper(userController.getBookmarkedOffers))
 router.patch('/:id', isEntityValid({ params }), asyncWrapper(userController.updateUser))
 router.patch('/deactivate/:id', isEntityValid({ params }), asyncWrapper(userController.deactivateUser))

--- a/src/utils/validationHelper.js
+++ b/src/utils/validationHelper.js
@@ -13,8 +13,26 @@ const validateRequired = (schemaFieldKey, required, field) => {
   }
 }
 
+const castValueToType = (value, type) => {
+  if (type === 'boolean' && value === 'true') {
+    return true
+  }
+
+  if (type === 'boolean' && value === 'false') {
+    return false
+  }
+
+  if (type === 'number') {
+    return Number(value)
+  }
+
+  return value
+}
+
 const validateType = (schemaFieldKey, type, field) => {
-  if (type != typeof field) {
+  const typeCastedField = castValueToType(field, type)
+
+  if (type != typeof typeCastedField) {
     throw createError(422, FIELD_IS_NOT_OF_PROPER_TYPE(schemaFieldKey, type))
   }
 }

--- a/src/validation/schemas/getUserById.js
+++ b/src/validation/schemas/getUserById.js
@@ -1,0 +1,16 @@
+const {
+  enums: { MAIN_ROLE_ENUM }
+} = require('~/consts/validation')
+
+const getUserByIdValidationSchema = {
+  role: {
+    enum: MAIN_ROLE_ENUM,
+    required: false
+  },
+  isEdit: {
+    type: 'boolean',
+    required: false
+  }
+}
+
+module.exports = getUserByIdValidationSchema


### PR DESCRIPTION
Fix invalid role parameter along with valid isEdit parameter in /users/{id} causing an error:
```
{
"status": 500,
"code": "INTERNAL_SERVER_ERROR",
"message": "Cannot read property 'mainSubjects' of null"
}
```

### Result of fix
Invalid role causes a 422 (validation) Unprocessable Entity error:

![image](https://github.com/user-attachments/assets/cb138e31-95ce-4524-8f61-3178c1a4b6b8)

Invalid isEdit causes a 422 (validation) Unprocessable Entity error:

![image](https://github.com/user-attachments/assets/45b93b50-b01d-4111-9da9-e7ca1977a2c3)

Valid params:
![image](https://github.com/user-attachments/assets/3cdd9129-7631-411d-929f-00cd84c48d29)

- add getUserByIdValidationSchema that validates both role and isEdit
- enhance validationMiddleware to handle body or query
- add 422 error to enpoint docs