### PR TITLE
Fix swagger duplication on GET /user/{id} endpoint

### DIFF
--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -53,7 +53,7 @@ paths:
                     }
                   totalReviews: { student: 10, tutor: 8 }
                   averageRating: { student: 4.5, tutor: 4.9 }
-                  nativeLanguage: english
+                  nativeLanguage: English
                   address: { country: The USA, city: California }
                   professionalSummary: KNPU H.S. Skovoroda
                   photo: john-doe-photo.jpg
@@ -95,7 +95,7 @@ paths:
                     }
                   totalReviews: { student: 0, tutor: 530 }
                   averageRating: { student: 0, tutor: 5 }
-                  nativeLanguage: ukrainian
+                  nativeLanguage: Ukrainian
                   address: { country: Ukraine, city: Kharkiv }
                   professionalSummary: KNPU H.S. Skovoroda
                   photo: joe-doe-photo.jpg
@@ -246,7 +246,7 @@ paths:
                   }
                 totalReviews: { student: 10, tutor: 0 }
                 averageRating: { student: 4.5, tutor: 0 }
-                nativeLanguage: english
+                nativeLanguage: English
                 address: { country: The USA, city: California }
                 professionalSummary: KNPU H.S. Skovoroda
                 photo: john-doe-photo.jpg

--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -220,101 +220,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/definitions/user'
-              examples:
-                example1:
-                  summary: Example 1
-                  value:
-                    _id: 6255bc080a75adf9223df100
-                    role: student
-                    firstName: John
-                    lastName: Doe
-                    email: johndoe@gmail.com
-                    mainSubjects:
-                      {
-                        student:
-                          [
+              example:
+                _id: 6255bc080a75adf9223df100
+                role: student
+                firstName: John
+                lastName: Doe
+                email: johndoe@gmail.com
+                mainSubjects:
+                  {
+                    student:
+                      [
+                        {
+                          _id: 64593435163b62124ce4c3ab,
+                          category:
                             {
-                              _id: 64593435163b62124ce4c3ab,
-                              category:
-                                {
-                                  _id: '6421ed8ed991d46a84721df2',
-                                  name: Cybersecurity,
-                                  appearance: { icon: 'IconName', color: '#123456' }
-                                },
-                              subjects: [{ _id: '6421ed8ed991d46a84721df2', name: 'XSS Attack' }],
-                              isDeletionBlocked: false
-                            }
-                          ],
-                        tutor: []
-                      }
-                    totalReviews: { student: 10, tutor: 0 }
-                    averageRating: { student: 4.5, tutor: 0 }
-                    nativeLanguage: english
-                    address: { country: The USA, city: California }
-                    ProfessionalSummary: KNPU H.S. Skovoroda
-                    photo: john-doe-photo.jpg
-                    status: { student: active, tutor: active, admin: active }
-                    isEmailConfirmed: true
-                    isFirstLogin: true
-                    lastLogin: 2022-09-02T11:59:53.243+00:00
-                    lastSeen: 2022-09-02T11:59:53.243+00:00
-                    bookmarkedOffers: []
-                    FAQ:
-                      {
-                        student: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }],
-                        tutor: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }]
-                      }
-                    videoLink:
-                      { student: www.youtube.com/watch?v=ebTnuLRnIOY, tutor: www.youtube.com/watch?v=ebTnuLRnIOY }
-                    createdAt: 2021-04-09T11:34:53.243+00:00
-                    updatedAt: 2022-09-02T11:59:53.243+00:00
-                example2:
-                  summary: Example 2
-                  value:
-                    _id: 6255bc080a75adf9223df100
-                    role: student
-                    firstName: John
-                    lastName: Doe
-                    email: johndoe@gmail.com
-                    mainSubjects:
-                      {
-                        student:
-                          [
-                            {
-                              _id: 64593435163b62124ce4c3ab,
-                              category:
-                                {
-                                  _id: '6421ed8ed991d46a84721df2',
-                                  name: Cybersecurity,
-                                  appearance: { icon: 'IconName', color: '#123456' }
-                                },
-                              subjects: [{ _id: '6421ed8ed991d46a84721df2', name: 'XSS Attack' }],
-                              isDeletionBlocked: false
-                            }
-                          ],
-                        tutor: []
-                      }
-                    totalReviews: { student: 10, tutor: 0 }
-                    averageRating: { student: 4.5, tutor: 0 }
-                    nativeLanguage: english
-                    address: { country: The USA, city: California }
-                    professionalSummary: KNPU H.S. Skovoroda
-                    photo: john-doe-photo.jpg
-                    status: { student: active, tutor: active, admin: active }
-                    isEmailConfirmed: true
-                    isFirstLogin: true
-                    lastLogin: 2022-09-02T11:59:53.243+00:00
-                    lastSeen: 2022-09-02T11:59:53.243+00:00
-                    bookmarkedOffers: []
-                    FAQ:
-                      {
-                        student: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }],
-                        tutor: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }]
-                      }
-                    videoLink:
-                      { student: www.youtube.com/watch?v=ebTnuLRnIOY, tutor: www.youtube.com/watch?v=ebTnuLRnIOY }
-                    createdAt: 2021-04-09T11:34:53.243+00:00
-                    updatedAt: 2022-09-02T11:59:53.243+00:00
+                              _id: '6421ed8ed991d46a84721df2',
+                              name: Cybersecurity,
+                              appearance: { icon: 'IconName', color: '#123456' }
+                            },
+                          subjects: [{ _id: '6421ed8ed991d46a84721df2', name: 'XSS Attack' }],
+                          isDeletionBlocked: false
+                        }
+                      ],
+                    tutor: []
+                  }
+                totalReviews: { student: 10, tutor: 0 }
+                averageRating: { student: 4.5, tutor: 0 }
+                nativeLanguage: english
+                address: { country: The USA, city: California }
+                professionalSummary: KNPU H.S. Skovoroda
+                photo: john-doe-photo.jpg
+                status: { student: active, tutor: active, admin: active }
+                isEmailConfirmed: true
+                isFirstLogin: true
+                lastLogin: 2022-09-02T11:59:53.243+00:00
+                lastSeen: 2022-09-02T11:59:53.243+00:00
+                bookmarkedOffers: []
+                FAQ:
+                  {
+                    student: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }],
+                    tutor: [{ question: tutor question, _id: 63525e23bf163f5ea609ff2b, answer: tutor answer }]
+                  }
+                videoLink:
+                  { student: www.youtube.com/watch?v=ebTnuLRnIOY, tutor: www.youtube.com/watch?v=ebTnuLRnIOY }
+                createdAt: 2021-04-09T11:34:53.243+00:00
+                updatedAt: 2022-09-02T11:59:53.243+00:00
         400:
           description: Bad Request
           content:


### PR DESCRIPTION
Removed an array of example values from `GET /user/{id}` endpoint and replaced it with single one
Capitalized values of `nativeLanguage` field to follow `SPOKEN_LANG_ENUM`

Before:
![image](https://github.com/user-attachments/assets/dfcb94b0-7c9f-43e3-b575-b5a452e6a1be)

After:
![image](https://github.com/user-attachments/assets/1af0ad6b-670c-4e0c-be20-7231ffb6cac2)
