### PR TITLE
Added aboutStudent field & extended update logic

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -220,6 +220,23 @@ const userSchema = new Schema(
       workExperience: { type: String, default: '', maxLength: [1000, FIELD_CANNOT_BE_LONGER('work experience', 1000)] },
       education: { type: String, default: '', maxLength: [1000, FIELD_CANNOT_BE_LONGER('education', 1000)] }
     },
+    aboutStudent: {
+      personalIntroduction: {
+        type: String,
+        default: '',
+        maxLength: [1000, FIELD_CANNOT_BE_LONGER('personal introduction', 1000)]
+      },
+      learningGoals: {
+        type: String,
+        default: '',
+        maxLength: [1000, FIELD_CANNOT_BE_LONGER('learning goals', 1000)]
+      },
+      learningActivities: {
+        type: String,
+        default: '',
+        maxLength: [1000, FIELD_CANNOT_BE_LONGER('learning activities', 1000)]
+      }
+    },
     notificationSettings: {
       isOfferStatusNotification: { type: Boolean, default: true },
       isChatNotification: { type: Boolean, default: true },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -18,6 +18,7 @@ const {
   roles: { ADMIN }
 } = require('~/consts/auth')
 const { allowedTutorFieldsForUpdate } = require('~/validation/services/user')
+const { allowedStudentFieldsForUpdate } = require('~/validation/services/user')
 const { shouldDeletePreviousPhoto } = require('~/utils/users/photoCheck')
 const offerService = require('./offer')
 const cooperationService = require('./cooperation')
@@ -135,7 +136,7 @@ const userService = {
     const allowedFields =
       role === MAIN_ROLE_ENUM[1]
         ? { ...allowedUserFieldsForUpdate, ...allowedTutorFieldsForUpdate }
-        : allowedUserFieldsForUpdate
+        : { ...allowedUserFieldsForUpdate, ...allowedStudentFieldsForUpdate }
 
     const filteredUpdateData = filterAllowedFields(updateData, allowedFields)
 

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -18,7 +18,8 @@ const {
   roles: { ADMIN }
 } = require('~/consts/auth')
 const { allowedTutorFieldsForUpdate } = require('~/validation/services/user')
-const { allowedStudentFieldsForUpdate } = require('~/validation/services/user')
+const { allowedTutorFieldsForUpdate, allowedStudentFieldsForUpdate } = require('~/validation/services/user')
+
 const { shouldDeletePreviousPhoto } = require('~/utils/users/photoCheck')
 const offerService = require('./offer')
 const cooperationService = require('./cooperation')

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -18,8 +18,7 @@ const {
   roles: { ADMIN }
 } = require('~/consts/auth')
 const { allowedTutorFieldsForUpdate } = require('~/validation/services/user')
-const { allowedTutorFieldsForUpdate, allowedStudentFieldsForUpdate } = require('~/validation/services/user')
-
+const { allowedStudentFieldsForUpdate } = require('~/validation/services/user')
 const { shouldDeletePreviousPhoto } = require('~/utils/users/photoCheck')
 const offerService = require('./offer')
 const cooperationService = require('./cooperation')

--- a/src/validation/services/user.js
+++ b/src/validation/services/user.js
@@ -30,7 +30,16 @@ const allowedTutorFieldsForUpdate = {
   }
 }
 
+const allowedStudentFieldsForUpdate = {
+  aboutStudent: {
+    personalIntroduction: true,
+    learningGoals: true,
+    learningActivities: true
+  }
+}
+
 module.exports = {
   allowedUserFieldsForUpdate,
-  allowedTutorFieldsForUpdate
+  allowedTutorFieldsForUpdate,
+  allowedStudentFieldsForUpdate
 }


### PR DESCRIPTION
- [x] added `aboutStudent` field to `User` schema. It is intended to store additional information about a student: his personal introduction, learning goals and learning activities.
- [x] extended allowed fields for update for availability to update this data

The PR is connected with [PR #2889](https://github.com/ita-social-projects/SpaceToStudy-Client/pull/2899) on frontend. If used at the same time, the logic of updating student data in `AboutStudentAccordion` on student `Edit profile` page is available.