### PR TITLE
Fix an ability to attach files on /attachments endpoint

### DIFF
--- a/docs/attachments/attachment.yaml
+++ b/docs/attachments/attachment.yaml
@@ -81,19 +81,17 @@ paths:
         - Attachments
       summary: Create new attachments.
       description: Saves new attachments to the database.
-      consumes:
-        - multipart/form-data
-      parameters:
-        - in: formData
-          name: files
-          type: file
-          description: Array of files to upload
-          required: true
-        - in: formData
-          name: fileName
-          type: string
-          description: File name for the attachment
-          required: true
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
       responses:
         201:
           description: Created


### PR DESCRIPTION
Rewrited swagger docs for `POST /attachments` endpoint:

- Removed redundant `fileName` field as it's already present in File type
- Added an ability to attach single file (or files) for real representing API functionality

Before: 
![image](https://github.com/user-attachments/assets/9e3e06d1-f946-4eaa-93ad-0bc248a58c21)

After:
![image](https://github.com/user-attachments/assets/cba99c3e-5fce-41a7-9f8f-e0b89cb9bb81)

Example of response with 2 files attached:
![image](https://github.com/user-attachments/assets/622ce908-1d44-4aef-a01e-020ad88e209d)
