### PR TITLE
Fix swagger auth on /chat/{id}/messages endpoint

### DIFF
--- a/docs/chat/chat.yaml
+++ b/docs/chat/chat.yaml
@@ -192,7 +192,7 @@ paths:
                 message: Chat with the specified id was not found.
     patch:
       security:
-        - bearerAuth: []
+        - cookieAuth: []
       tags:
         - Chats
       summary: Clears chat history for current user


### PR DESCRIPTION
Updated auth properties for `PATCH /chat/{id}/messages` endpoint to follow the project configuration.

Before:
![image](https://github.com/user-attachments/assets/b6e09bec-41db-4660-961a-7bfe8ac38e29)

After:
![image](https://github.com/user-attachments/assets/0da1df33-ce8c-4a85-b886-7f9f44cfb662)
