### PR TITLE
Fix status code in GET /users/{id} swagger example

### DIFF
--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -328,7 +328,7 @@ paths:
               schema:
                 $ref: '#/components/Error'
               example:
-                status: 404
+                status: 401
                 code: 'UNAUTHORIZED'
                 message: 'The requested URL requires user authorization.'
         404:


### PR DESCRIPTION
Updated status code in `GET /users/{id}` from 404 to 401

Before:
![image](https://github.com/user-attachments/assets/c46b703e-5566-4745-901f-2958c5e53bd6)

After:
![image](https://github.com/user-attachments/assets/99047208-0155-4b8a-9e79-f217ec508e4a)
