### PR TITLE
SP(0.5): Add 409 response in Swagger docs for user patch

### DIFF
--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -373,6 +373,16 @@ paths:
                 status: 404
                 code: 'DOCUMENT_NOT_FOUND'
                 message: 'User with the specified id was not found.'
+        409:
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/Error'
+              example:
+                status: 409
+                code: 'VALIDATION_ERROR'
+                message: 'Validation for new user info failed.'
     delete:
       security:
         - cookieAuth: []


### PR DESCRIPTION
Status code 409 Conflict wasn't documented in the Swagger documentation for endpoint {server}/users/{id} (PATCH method):

![image](https://github.com/user-attachments/assets/b4585d89-7bdb-4797-965b-c127a5e9f4a9)

After fix:
![image](https://github.com/user-attachments/assets/e3330fbd-d7b8-4ce0-9700-8cd7db9c97bd)
![image](https://github.com/user-attachments/assets/f5c6a5ab-4553-46cf-9a97-10269e15d9de)
