### PR TITLE
Fix incorrect swagger example in Chats section

### DIFF
--- a/docs/chat/chat-schema.yaml
+++ b/docs/chat/chat-schema.yaml
@@ -23,14 +23,10 @@ definitions:
   chatBody:
     type: object
     properties:
-      members:
-        type: object
-        properties:
-          user:
-            type: string
-            ref: '#/components/user'
-          role:
-            type: string
+      member:
+        type: string
+      memberRole:
+        type: string
   chat:
     type: object
     properties:

--- a/docs/chat/chat.yaml
+++ b/docs/chat/chat.yaml
@@ -16,8 +16,9 @@ paths:
           application/json:
             schema:
               $ref: '#/definitions/chatBody'
-            member: 6421d9833cdf38b706756dff
-            memberRole: student
+            example:
+              member: 6421d9833cdf38b706756dff
+              memberRole: student
       responses:
         201:
           description: OK


### PR DESCRIPTION
- Updated `requestBody` example in `POST` on `/chats` endpoint
- Fixed incorrect `requestBody` schema in `chat-schema.yaml`

Before:
![image](https://github.com/user-attachments/assets/e82adfb5-649b-4593-ae6b-d1028cad5551)
![image](https://github.com/user-attachments/assets/4be994f8-21a6-47bf-a027-4db31ccfbe76)


After:
![image](https://github.com/user-attachments/assets/b186dbe1-f468-4d7f-80b3-4c735aa56b85)
![image](https://github.com/user-attachments/assets/9099df13-a990-48f5-819f-915eb9c2c338)

