### PR TITLE
Fixed swagger description for getting chat messages

### DIFF
--- a/docs/chat/chat.yaml
+++ b/docs/chat/chat.yaml
@@ -85,8 +85,7 @@ paths:
       tags:
         - Chats
       summary: Find your messages in chat
-      description: >-
-        Finds and returns an array with a list of all your messages related to
+      description: Finds and returns an array with a list of all your messages related to
         specific chat.
       produces:
         - application/json


### PR DESCRIPTION
**Description:** Removed redundant symbols in /chats/{id}/messages get description.

Now swagger for getting chat messages looks like this:

![Screenshot 2024-12-11 223556](https://github.com/user-attachments/assets/b0d9b7f8-5fc3-41b3-a65b-fba3e88f3a34)
