### PR TITLE
Fixed incorrect schema in docs on GET 200 in `/categories/{categoryId}/subjects/{subjectId}/price-range`

### DIFF
--- a/docs/category/category-schema.yaml
+++ b/docs/category/category-schema.yaml
@@ -1,4 +1,11 @@
 definitions:
+  priceRange:
+    type: object
+    properties:
+      minPrice:
+        type: number
+      maxPrice:
+        type: number
   categories:
     type: array
     items:

--- a/docs/category/category.yaml
+++ b/docs/category/category.yaml
@@ -276,7 +276,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/offer'
+                $ref: '#/definitions/priceRange'
               example:
                 minPrice: 300
                 maxPrice: 500


### PR DESCRIPTION
Example value:
<img width="333" alt="Screenshot 2024-12-13 at 15 03 41" src="https://github.com/user-attachments/assets/4b4b69c1-d48b-4466-be23-c908ae0016fc" />

Schema before:
<img width="369" alt="Screenshot 2024-12-13 at 15 03 22" src="https://github.com/user-attachments/assets/31f59f43-b452-4697-8458-ee48ad7e1cb2" />

Schema after:
<img width="340" alt="Screenshot 2024-12-13 at 15 03 31" src="https://github.com/user-attachments/assets/c1ca6508-caa7-466f-91a6-10871298ca09" />
