### PR TITLE
The resourceType field was removed from the quiz and the cooperations were updated

### DIFF
--- a/migrations/20241212093509-remove-resourceType-from-quiz.js
+++ b/migrations/20241212093509-remove-resourceType-from-quiz.js
@@ -1,0 +1,30 @@
+module.exports = {
+  async up(db) {
+    const quizCollection = db.collection('quizzes')
+    const cooperationsCollection = db.collection('cooperation')
+
+    const quizzes = await quizCollection.find({}).toArray()
+    for (const quiz of quizzes) {
+      if (quiz.resourceType) {
+        await cooperationsCollection.updateMany(
+          { 'sections.resources.resource': quiz._id },
+          { $set: { 'sections.$[section].resources.$[res].resourceType': quiz.resourceType } },
+          {
+            arrayFilters: [{ 'section.resources.resource': quiz._id }, { 'res.resource': quiz._id }]
+          }
+        )
+      }
+    }
+    await quizCollection.updateMany({}, { $unset: { resourceType: '' } })
+  },
+
+  async down(db) {
+    const quizCollection = db.collection('quizzes')
+    const cooperationsCollection = db.collection('cooperation')
+    await cooperationsCollection.updateMany(
+      { 'sections.resources.resource': { $exists: true } },
+      { $unset: { 'sections.$[].resources.$[].resourceType': '' } }
+    )
+    await quizCollection.updateMany({}, { $set: { resourceType: 'quiz' } })
+  }
+}

--- a/src/test/migrations/20241212093509-remove-resourceType-from-quiz.spec.js
+++ b/src/test/migrations/20241212093509-remove-resourceType-from-quiz.spec.js
@@ -22,6 +22,7 @@ describe('20241203085442-remove-resource-type-from-quizzes', () => {
   })
 
   afterAll(async () => {
+    await up(database)
     await client.close()
   })
 

--- a/src/test/migrations/20241212093509-remove-resourceType-from-quiz.spec.js
+++ b/src/test/migrations/20241212093509-remove-resourceType-from-quiz.spec.js
@@ -1,0 +1,80 @@
+const { MongoClient, ObjectId } = require('mongodb')
+const { up, down } = require('@root/migrations/20241212093509-remove-resourceType-from-quiz')
+
+require('~/initialization/envSetup')
+const {
+  config: { MONGODB_URL }
+} = require('~/configs/config')
+
+const quizCollectionName = 'quizzes'
+const cooperationCollectionName = 'cooperation'
+
+const url = MONGODB_URL.slice(0, MONGODB_URL.lastIndexOf('/'))
+const databaseName = MONGODB_URL.slice(MONGODB_URL.lastIndexOf('/') + 1)
+
+describe('20241203085442-remove-resource-type-from-quizzes', () => {
+  let client, database
+
+  beforeAll(async () => {
+    client = new MongoClient(url)
+    database = client.db(databaseName)
+    await client.connect()
+  })
+
+  afterAll(async () => {
+    await client.close()
+  })
+
+  test('should remove resourceType from quizzes on migrate up', async () => {
+    await database.collection(quizCollectionName).insertOne({
+      _id: ObjectId(),
+      resourceType: 'quiz'
+    })
+
+    await up(database)
+
+    const quiz = await database.collection(quizCollectionName).findOne({ resourceType: 'quiz' })
+    expect(quiz).toBeNull()
+  })
+
+  test('should update cooperation documents with correct resourceType removal', async () => {
+    const quizId = (
+      await database.collection(quizCollectionName).insertOne({
+        _id: ObjectId(),
+        resourceType: 'quiz'
+      })
+    ).insertedId
+
+    await database.collection(cooperationCollectionName).insertOne({
+      sections: [
+        {
+          resources: [{ resource: quizId, resourceType: 'quiz' }]
+        }
+      ]
+    })
+
+    await up(database)
+    const cooperation = await database.collection(cooperationCollectionName).findOne({
+      'sections.resources.resource': quizId
+    })
+    const quiz = await database.collection(quizCollectionName).findOne({
+      _id: quizId
+    })
+
+    expect(quiz.resourceType).toBeUndefined()
+
+    expect(cooperation.sections[0].resources[0].resourceType).toBe('quiz')
+  })
+
+  test('should restore resourceType during migrate down', async () => {
+    const quizId = ObjectId()
+    await database.collection(quizCollectionName).insertOne({
+      _id: quizId
+    })
+
+    await down(database)
+
+    const quiz = await database.collection(quizCollectionName).findOne({ _id: quizId })
+    expect(quiz.resourceType).toBe('quiz')
+  })
+})


### PR DESCRIPTION
Migration to remove the resourceType field from the quiz and to update the corresponding cooperations documents has been written, tests for migration have also been written