### PR TITLE
Add missed fields in chat schema & update examples in Swagger docs

### DIFF
--- a/docs/chat/chat-schema.yaml
+++ b/docs/chat/chat-schema.yaml
@@ -10,7 +10,7 @@ definitions:
           type: object
           properties:
             user:
-              type: string
+              type: object
               $ref: '#/components/user'
             role:
               type: string
@@ -20,6 +20,17 @@ definitions:
         updatedAt:
           type: string
           format: date-time
+        deletedFor:
+          type: array
+          items:
+            type: object
+            properties:
+              user:
+                type: object
+                $ref: '#/components/user'
+        latestMessage:
+          type: string
+          $ref: '#/definitions/message'
   chatBody:
     type: object
     properties:
@@ -36,7 +47,7 @@ definitions:
         type: object
         properties:
           user:
-            type: string
+            type: object
             ref: '#/components/user'
           role:
             type: string
@@ -46,3 +57,14 @@ definitions:
       updatedAt:
         type: string
         format: date-time
+      deletedFor:
+        type: array
+        items:
+          type: object
+          properties:
+            user:
+              type: object
+              $ref: '#/components/user'
+      latestMessage:
+        type: string
+        $ref: '#/definitions/message'

--- a/docs/chat/chat-schema.yaml
+++ b/docs/chat/chat-schema.yaml
@@ -7,11 +7,11 @@ definitions:
         _id:
           type: string
         members:
-          type: object
+          type: array
           properties:
             user:
               type: object
-              $ref: '#/components/user'
+              $ref: '#/definitions/user'
             role:
               type: string
         createdAt:
@@ -27,9 +27,9 @@ definitions:
             properties:
               user:
                 type: object
-                $ref: '#/components/user'
+                $ref: '#/definitions/user'
         latestMessage:
-          type: string
+          type: object
           $ref: '#/definitions/message'
   chatBody:
     type: object
@@ -48,7 +48,7 @@ definitions:
         properties:
           user:
             type: object
-            ref: '#/components/user'
+            ref: '#/definitions/user'
           role:
             type: string
       createdAt:
@@ -64,7 +64,7 @@ definitions:
           properties:
             user:
               type: object
-              $ref: '#/components/user'
+              $ref: '#/definitions/user'
       latestMessage:
-        type: string
+        type: object
         $ref: '#/definitions/message'

--- a/docs/chat/chat-schema.yaml
+++ b/docs/chat/chat-schema.yaml
@@ -10,8 +10,7 @@ definitions:
           type: array
           properties:
             user:
-              type: object
-              $ref: '#/definitions/user'
+              $ref: '#/definitions/userAsMember'
             role:
               type: string
         createdAt:
@@ -26,8 +25,7 @@ definitions:
             type: object
             properties:
               user:
-                type: object
-                $ref: '#/definitions/user'
+                type: string
         latestMessage:
           type: object
           $ref: '#/definitions/message'
@@ -48,7 +46,7 @@ definitions:
         properties:
           user:
             type: object
-            ref: '#/definitions/user'
+            $ref: '#/definitions/userAsMember'
           role:
             type: string
       createdAt:
@@ -63,8 +61,24 @@ definitions:
           type: object
           properties:
             user:
-              type: object
-              $ref: '#/definitions/user'
+              type: string
       latestMessage:
         type: object
         $ref: '#/definitions/message'
+  userAsMember:
+    type: object
+    properties:
+      _id:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      photo:
+        type: string
+      professionalSummary:
+        type: string
+    required:
+      - _id
+      - firstName
+      - lastName

--- a/docs/chat/chat-schema.yaml
+++ b/docs/chat/chat-schema.yaml
@@ -27,7 +27,6 @@ definitions:
               user:
                 type: string
         latestMessage:
-          type: object
           $ref: '#/definitions/message'
   chatBody:
     type: object
@@ -45,7 +44,6 @@ definitions:
         type: object
         properties:
           user:
-            type: object
             $ref: '#/definitions/userAsMember'
           role:
             type: string
@@ -63,7 +61,6 @@ definitions:
             user:
               type: string
       latestMessage:
-        type: object
         $ref: '#/definitions/message'
   userAsMember:
     type: object

--- a/docs/chat/chat-schema.yaml
+++ b/docs/chat/chat-schema.yaml
@@ -1,34 +1,4 @@
 definitions:
-  chats:
-    type: array
-    items:
-      type: object
-      properties:
-        _id:
-          type: string
-        members:
-          type: array
-          properties:
-            user:
-              $ref: '#/definitions/userChatMember'
-            role:
-              type: string
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
-        deletedFor:
-          type: array
-          items:
-            type: object
-            properties:
-              user:
-                type: string
-        latestMessage:
-          $ref: '#/definitions/message'
-          nullable: true
   chatBody:
     type: object
     properties:
@@ -64,6 +34,10 @@ definitions:
       latestMessage:
         $ref: '#/definitions/message'
         nullable: true
+  chats:
+    type: array
+    items:
+      $ref: '#/definitions/chat'
   userChatMember:
     type: object
     properties:

--- a/docs/chat/chat-schema.yaml
+++ b/docs/chat/chat-schema.yaml
@@ -10,7 +10,7 @@ definitions:
           type: array
           properties:
             user:
-              $ref: '#/definitions/userAsMember'
+              $ref: '#/definitions/userChatMember'
             role:
               type: string
         createdAt:
@@ -28,6 +28,7 @@ definitions:
                 type: string
         latestMessage:
           $ref: '#/definitions/message'
+          nullable: true
   chatBody:
     type: object
     properties:
@@ -44,7 +45,7 @@ definitions:
         type: object
         properties:
           user:
-            $ref: '#/definitions/userAsMember'
+            $ref: '#/definitions/userChatMember'
           role:
             type: string
       createdAt:
@@ -62,7 +63,8 @@ definitions:
               type: string
       latestMessage:
         $ref: '#/definitions/message'
-  userAsMember:
+        nullable: true
+  userChatMember:
     type: object
     properties:
       _id:
@@ -75,7 +77,3 @@ definitions:
         type: string
       professionalSummary:
         type: string
-    required:
-      - _id
-      - firstName
-      - lastName

--- a/docs/chat/chat.yaml
+++ b/docs/chat/chat.yaml
@@ -60,7 +60,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/chat'
+                $ref: '#/definitions/chats'
               example:
                 - _id: 67604def753afa7bbd3bd98a
                   members:

--- a/docs/chat/chat.yaml
+++ b/docs/chat/chat.yaml
@@ -67,12 +67,14 @@ paths:
                     - user:
                         _id: 67519181170a70623366d30c
                         firstName: Diana
-                        lastName: Test
+                        lastName: Romovych
+                        professionalSummary: ""
+                        photo: null
                       role: tutor
                     - user:
                         _id: 673f342709e56a9071f5308c
-                        firstName: valya
-                        lastName: dudchak
+                        firstName: Valentyna
+                        lastName: Dudchak
                         professionalSummary: ""
                         photo: 1733337385040-photofordemo.jpg
                       role: student
@@ -84,9 +86,9 @@ paths:
                     author:
                       _id: 67519181170a70623366d30c
                       firstName: Diana
-                      lastName: Test
+                      lastName: Romovych
                     authorRole: tutor
-                    text: hi test message
+                    text: Hi! How is your assignment going?
                     chat: 67604def753afa7bbd3bd98a
                     clearedFor: []
                     createdAt: 2024-12-16T15:57:35.862Z
@@ -96,12 +98,16 @@ paths:
                     - user:
                         _id: 67519181170a70623366d30c
                         firstName: Diana
-                        lastName: Test
+                        lastName: Romovych
+                        professionalSummary: ""
+                        photo: null
                       role: tutor
                     - user:
                         _id: 6735ff2cc8f5e44cc3de002d
                         firstName: Pavlo
                         lastName: Butynets
+                        professionalSummary: ""
+                        photo: null
                       role: student
                   createdAt: 2024-12-16T16:01:14.667Z
                   updatedAt: 2024-12-16T16:01:14.991Z
@@ -111,9 +117,9 @@ paths:
                     author:
                       _id: 67519181170a70623366d30c
                       firstName: Diana
-                      lastName: Test
+                      lastName: Romovych
                     authorRole: tutor
-                    text: hi test
+                    text: Hi! Are there any issues with your assignment?
                     chat: 67604eca753afa7bbd3bd9c1
                     clearedFor: []
                     createdAt: 2024-12-16T16:01:14.916Z

--- a/docs/chat/chat.yaml
+++ b/docs/chat/chat.yaml
@@ -368,12 +368,17 @@ paths:
               schema:
                 $ref: '#/definitions/chat'
               example:
-                - _id: 64a54c6c7bca605aaf2da66c
-                  members:
-                    [{ user: 6491d003a634c3c427b69daa, role: tutor }, { user: 6421d9833cdf38b706756dff, role: student }]
-                  deletedFor: [{ user: 6491d003a634c3c427b69daa }]
-                  createdAt: 2023-20-01T13:25:36.292Z
-                  updatedAt: 2023-20-01T13:25:36.292Z
+                _id: 67604eca753afa7bbd3bd9c1
+                members:
+                  - user: 67519181170a70623366d30c
+                    role: tutor
+                  - user: 6735ff2cc8f5e44cc3de002d
+                    role: student
+                deletedFor:
+                  - user: 67519181170a70623366d30c
+                createdAt: 2024-12-16T16:01:14.667Z
+                updatedAt: 2024-12-16T16:20:01.463Z
+                latestMessage: 67604eca753afa7bbd3bd9c3
         400:
           description: Bad Request
           content:

--- a/docs/chat/chat.yaml
+++ b/docs/chat/chat.yaml
@@ -62,22 +62,62 @@ paths:
               schema:
                 $ref: '#/definitions/chat'
               example:
-                - _id: 64a54c6c7bca605aaf2da66c
+                - _id: 67604def753afa7bbd3bd98a
                   members:
-                    - user: 6491d003a634c3c427b69daa
+                    - user:
+                        _id: 67519181170a70623366d30c
+                        firstName: Diana
+                        lastName: Test
                       role: tutor
-                    - user: 6421d9833cdf38b706756dff
+                    - user:
+                        _id: 673f342709e56a9071f5308c
+                        firstName: valya
+                        lastName: dudchak
+                        professionalSummary: ""
+                        photo: 1733337385040-photofordemo.jpg
                       role: student
-                  createdAt: 2024-08-01T13:25:36.292Z
-                  updatedAt: 2024-08-01T13:25:36.292Z
-                - _id: 64a54c6c7bca605aaf2da6df
+                  createdAt: 2024-12-16T15:57:35.632Z
+                  updatedAt: 2024-12-16T15:57:35.949Z
+                  deletedFor: []
+                  latestMessage:
+                    _id: 67604def753afa7bbd3bd98c
+                    author:
+                      _id: 67519181170a70623366d30c
+                      firstName: Diana
+                      lastName: Test
+                    authorRole: tutor
+                    text: hi test message
+                    chat: 67604def753afa7bbd3bd98a
+                    clearedFor: []
+                    createdAt: 2024-12-16T15:57:35.862Z
+                    updatedAt: 2024-12-16T15:57:35.862Z
+                - _id: 67604eca753afa7bbd3bd9c1
                   members:
-                    - user: 6491d003a634c3c427b69dda
-                      role: student
-                    - user: 6421d9833cdf38b706756d22
+                    - user:
+                        _id: 67519181170a70623366d30c
+                        firstName: Diana
+                        lastName: Test
                       role: tutor
-                  createdAt: 2024-08-01T13:25:36.292Z
-                  updatedAt: 2024-08-01T13:25:36.292Z
+                    - user:
+                        _id: 6735ff2cc8f5e44cc3de002d
+                        firstName: Pavlo
+                        lastName: Butynets
+                      role: student
+                  createdAt: 2024-12-16T16:01:14.667Z
+                  updatedAt: 2024-12-16T16:01:14.991Z
+                  deletedFor: []
+                  latestMessage:
+                    _id: 67604eca753afa7bbd3bd9c3
+                    author:
+                      _id: 67519181170a70623366d30c
+                      firstName: Diana
+                      lastName: Test
+                    authorRole: tutor
+                    text: hi test
+                    chat: 67604eca753afa7bbd3bd9c1
+                    clearedFor: []
+                    createdAt: 2024-12-16T16:01:14.916Z
+                    updatedAt: 2024-12-16T16:01:14.916Z
   /chats/{id}/messages:
     get:
       security:

--- a/docs/chat/chat.yaml
+++ b/docs/chat/chat.yaml
@@ -68,14 +68,14 @@ paths:
                         _id: 67519181170a70623366d30c
                         firstName: Diana
                         lastName: Romovych
-                        professionalSummary: ""
+                        professionalSummary: ''
                         photo: null
                       role: tutor
                     - user:
                         _id: 673f342709e56a9071f5308c
                         firstName: Valentyna
                         lastName: Dudchak
-                        professionalSummary: ""
+                        professionalSummary: ''
                         photo: 1733337385040-photofordemo.jpg
                       role: student
                   createdAt: 2024-12-16T15:57:35.632Z
@@ -99,14 +99,14 @@ paths:
                         _id: 67519181170a70623366d30c
                         firstName: Diana
                         lastName: Romovych
-                        professionalSummary: ""
+                        professionalSummary: ''
                         photo: null
                       role: tutor
                     - user:
                         _id: 6735ff2cc8f5e44cc3de002d
                         firstName: Pavlo
                         lastName: Butynets
-                        professionalSummary: ""
+                        professionalSummary: ''
                         photo: null
                       role: student
                   createdAt: 2024-12-16T16:01:14.667Z


### PR DESCRIPTION
**Description:** Improved the `Chat` schema documentation in Swagger by adding missing fields, fixing existing issues, and updating examples to align with the API's actual behavior.

**Added missing fields:** 

- `deletedFor` - an array of users for whom the chat is marked as deleted;
- `latestMessage` - a reference to the most recent message in the chat.

**Updated examples for chats:**

- get `/chats`, 200 response - getting all chats for a current user;
- patch `/chats/{id}`, 200 response - marking a chat as deleted for the current user.

**Fixed issues:**

1. Fixed type of `user`. Created `userChatMember` scheme with the relevant fields for users as chat members, and changed the type of user in `deletedFor` to string, as it's just an id.
2. Fixed chats scheme & added correct definition to scheme in getting all chats. 

**`userChatMember` scheme in Swagger:**

<img width="505" alt="Screenshot 2024-12-27 214046" src="https://github.com/user-attachments/assets/eacd426b-4a5a-4b23-8a0f-898304d68b01" />

**`chats` scheme:**

![image](https://github.com/user-attachments/assets/14e678b6-c681-4149-84d3-26488f7aa92b)


**Corrected chat examples:**

![Screenshot 2024-12-27 214139](https://github.com/user-attachments/assets/8e7adfe5-7e33-421e-9c5c-795c6b2b2484)

![image](https://github.com/user-attachments/assets/9bceeb82-af9a-4a43-9729-c6a67c063c18)
