### PR TITLE
Changed category fields in /courses endpoint

### DIFF
--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -148,6 +148,7 @@ definitions:
         type: string
       category:
         type: string
+        nullable: true
       resourceType:
         $ref: '#/definitions/resourceType'
       settings:
@@ -167,12 +168,6 @@ definitions:
             type: boolean
           correctAnswers:
             type: boolean
-      createdAt:
-        type: string
-        format: date-time
-      updatedAt:
-        type: string
-        format: date-time
       isDuplicate:
         type: boolean
         description: Only present when the resource is a copy
@@ -191,18 +186,13 @@ definitions:
         type: string
       category:
         type: string
+        nullable: true
       resourceType:
         $ref: '#/definitions/resourceType'
       attachments:
         type: array
         items:
           type: string
-      createdAt:
-        type: string
-        format: date-time
-      updatedAt:
-        type: string
-        format: date-time
       isDuplicate:
         type: boolean
         description: Only present when the resource is a copy
@@ -218,17 +208,12 @@ definitions:
       link:
         type: string
       category:
-        $ref: '#/definitions/categoryWithName'
+        type: string
+        nullable: true
       resourceType:
         $ref: '#/definitions/resourceType'
       size:
         type: number
-      createdAt:
-        type: string
-        format: date-time
-      updatedAt:
-        type: string
-        format: date-time
       isDuplicate:
         type: boolean
         description: Only present when the resource is a copy

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -73,7 +73,7 @@ definitions:
         description: We get the ID of the chosen category
       subject:
         type: string
-        $ref: '#components/subject'
+        description: This ID related to subject
       proficiencyLevel:
         type: array
         items:

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -75,16 +75,7 @@ definitions:
         type: string
         description: This ID related to subject
       proficiencyLevel:
-        type: array
-        items:
-          type: string
-          enum:
-            - Beginner
-            - Intermediate
-            - Advanced
-            - Test Preparation
-            - Professional
-            - Specialized
+        $ref: '#/definitions/offerProficiencyLevelValues'
       sections:
         type: array
         items:
@@ -107,12 +98,7 @@ definitions:
                       - $ref: '#/definitions/attachment'
                       - $ref: '#/definitions/question'
                   resourceType:
-                    type: string
-                    enum:
-                      - lesson
-                      - quiz
-                      - attachment
-                      - question
+                    $ref: '#/definitions/resourceType'
       createdAt:
         type: string
         format: date-time
@@ -251,7 +237,7 @@ definitions:
         properties:
           isDuplicate:
             type: boolean
-            description: 'Only present when the resource is a copy'
+            description: Only present when the resource is a copy
   resourcesInCourse:
     oneOf:
       - $ref: '#/definitions/lessonInCourse'

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -42,31 +42,6 @@ definitions:
         type: string
       author:
         type: string
-      category:
-        type: string
-      subject:
-        type: string
-      proficiencyLevel:
-        $ref: '#/definitions/offerProficiencyLevelValues'
-      sections:
-        $ref: '#/definitions/courseSections'
-      createdAt:
-        type: string
-        format: date-time
-      updatedAt:
-        type: string
-        format: date-time
-  courseWithCategoryId:
-    type: object
-    properties:
-      _id:
-        type: string
-      title:
-        type: string
-      description:
-        type: string
-      author:
-        type: string
         description: This ID related to user
       category:
         type: string
@@ -77,28 +52,7 @@ definitions:
       proficiencyLevel:
         $ref: '#/definitions/offerProficiencyLevelValues'
       sections:
-        type: array
-        items:
-          type: object
-          properties:
-            title:
-              type: string
-            description:
-              type: string
-            resources:
-              type: array
-              items:
-                type: object
-                properties:
-                  resource:
-                    type: object
-                    oneOf:
-                      - $ref: '#/definitions/lesson'
-                      - $ref: '#/definitions/quiz'
-                      - $ref: '#/definitions/attachment'
-                      - $ref: '#/definitions/question'
-                  resourceType:
-                    $ref: '#/definitions/resourceType'
+        $ref: '#/definitions/courseSections'
       createdAt:
         type: string
         format: date-time
@@ -193,7 +147,7 @@ definitions:
       author:
         type: string
       category:
-        $ref: '#/definitions/categoryWithName'
+        type: string
       resourceType:
         $ref: '#/definitions/resourceType'
       settings:
@@ -223,21 +177,61 @@ definitions:
         type: boolean
         description: Only present when the resource is a copy
   lessonInCourse:
-    allOf:
-      - $ref: '#/definitions/lesson'
-      - type: object
-        properties:
-          isDuplicate:
-            type: boolean
-            description: Only present when the resource is a copy
+    type: object
+    properties:
+      _id:
+        type: string
+      author:
+        type: string
+      title:
+        type: string
+      description:
+        type: string
+      content:
+        type: string
+      category:
+        type: string
+      resourceType:
+        $ref: '#/definitions/resourceType'
+      attachments:
+        type: array
+        items:
+          type: string
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
+      isDuplicate:
+        type: boolean
+        description: Only present when the resource is a copy
   attachmentInCourse:
-    allOf:
-      - $ref: '#/definitions/attachmentInPostLesson'
-      - type: object
-        properties:
-          isDuplicate:
-            type: boolean
-            description: Only present when the resource is a copy
+    type: object
+    properties:
+      _id:
+        type: string
+      author:
+        type: string
+      fileName:
+        type: string
+      link:
+        type: string
+      category:
+        $ref: '#/definitions/categoryWithName'
+      resourceType:
+        $ref: '#/definitions/resourceType'
+      size:
+        type: number
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
+      isDuplicate:
+        type: boolean
+        description: Only present when the resource is a copy
   resourcesInCourse:
     oneOf:
       - $ref: '#/definitions/lessonInCourse'

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -67,13 +67,13 @@ definitions:
         type: string
       author:
         type: string
-        ref: '#components/user'
+        description: This ID related to user
       category:
         type: string
-        description: 'We get the ID of the chosen category'
+        description: We get the ID of the chosen category
       subject:
         type: string
-        ref: '#components/subject'
+        $ref: '#components/subject'
       proficiencyLevel:
         type: array
         items:
@@ -90,8 +90,10 @@ definitions:
         items:
           type: object
           properties:
-            title: string
-            description: string
+            title:
+              type: string
+            description:
+              type: string
             resources:
               type: array
               items:
@@ -99,13 +101,18 @@ definitions:
                 properties:
                   resource:
                     type: object
-                    additionalProperties: true
+                    oneOf:
+                      - $ref: '#/definitions/lesson'
+                      - $ref: '#/definitions/quiz'
+                      - $ref: '#/definitions/attachment'
+                      - $ref: '#/definitions/question'
                   resourceType:
                     type: string
                     enum:
                       - lesson
                       - quiz
                       - attachment
+                      - question
       createdAt:
         type: string
         format: date-time

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -56,6 +56,62 @@ definitions:
       updatedAt:
         type: string
         format: date-time
+  courseWithCategoryId:
+    type: object
+    properties:
+      _id:
+        type: string
+      title:
+        type: string
+      description:
+        type: string
+      author:
+        type: string
+        ref: '#components/user'
+      category:
+        type: string
+        description: 'We get the ID of the chosen category'
+      subject:
+        type: string
+        ref: '#components/subject'
+      proficiencyLevel:
+        type: array
+        items:
+          type: string
+          enum:
+            - Beginner
+            - Intermediate
+            - Advanced
+            - Test Preparation
+            - Professional
+            - Specialized
+      sections:
+        type: array
+        items:
+          type: object
+          properties:
+            title: string
+            description: string
+            resources:
+              type: array
+              items:
+                type: object
+                properties:
+                  resource:
+                    type: object
+                    additionalProperties: true
+                  resourceType:
+                    type: string
+                    enum:
+                      - lesson
+                      - quiz
+                      - attachment
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
   courseBody:
     type: object
     properties:

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -191,7 +191,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#definitions/course'
+                $ref: '#definitions/courseWithCategoryId'
               example:
                 title: Advanced English
                 description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
@@ -313,7 +313,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#definitions/course'
+                $ref: '#definitions/courseWithCategoryId'
               example:
                 title: Advanced English
                 description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -191,7 +191,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#definitions/courseWithCategoryId'
+                $ref: '#/definitions/course'
               example:
                 title: Advanced English
                 description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
@@ -313,7 +313,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#definitions/courseWithCategoryId'
+                $ref: '#/definitions/course'
               example:
                 title: Advanced English
                 description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.


### PR DESCRIPTION
Problem: Some category fields have an object with fields as an example, some have just string with id. Check courseService and update those examples with real values from API

Now: category fields changed to actual API response