### PR TITLE
Add cron job for opening scheduled cooperation resources

### DIFF
--- a/src/cron-jobs/openScheduledCooperationResources.js
+++ b/src/cron-jobs/openScheduledCooperationResources.js
@@ -1,0 +1,25 @@
+const { CronJob } = require('cron')
+
+const cooperationService = require('~/services/cooperation')
+
+const EVERY_MIDNIGHT = '00 00 * * *'
+const UTC_TIME_ZONE = 'UTC'
+
+const updateScheduledResources = async () => {
+  const currentDate = new Date()
+
+  await cooperationService.openScheduledCooperationResources(currentDate)
+}
+
+const openScheduledCooperationResources = new CronJob(
+  EVERY_MIDNIGHT,
+  updateScheduledResources,
+  null,
+  false,
+  UTC_TIME_ZONE
+)
+
+module.exports = {
+  openScheduledCooperationResources,
+  updateScheduledResources
+}

--- a/src/cron-jobs/scheduledCronJobs.js
+++ b/src/cron-jobs/scheduledCronJobs.js
@@ -1,9 +1,11 @@
 const { checkUsersForLastLogin } = require('~/cron-jobs/checkForLastLogin')
 const { removeUnverifiedUsers } = require('~/cron-jobs/removeUnverifiedUsers')
+const { openScheduledCooperationResources } = require('~/cron-jobs/openScheduledCooperationResources')
 
 const scheduledCronJobs = () => {
   checkUsersForLastLogin.start()
   removeUnverifiedUsers.start()
+  openScheduledCooperationResources.start()
 }
 
 module.exports = scheduledCronJobs

--- a/src/services/cooperation.js
+++ b/src/services/cooperation.js
@@ -154,6 +154,37 @@ const cooperationService = {
       .exec()
 
     return proficiencyLevel?.proficiencyLevel ?? null
+  },
+
+  openScheduledCooperationResources: async (currentDate) => {
+    await Cooperation.updateMany(
+      {
+        sections: { $exists: true },
+        'sections.resources': { $exists: true },
+        'sections.resources.availability.status': 'openFrom',
+        'sections.resources.availability.data': {
+          $ne: null,
+          $lte: currentDate
+        }
+      },
+      {
+        $set: {
+          'sections.$[].resources.$[resource].availability.status': 'open',
+          'sections.$[].resources.$[resource].availability.date': null
+        }
+      },
+      {
+        arrayFilters: [
+          {
+            resource: { $exists: true },
+            'resource.availability.date': {
+              $ne: null,
+              $lte: currentDate
+            }
+          }
+        ]
+      }
+    )
   }
 }
 

--- a/src/test/unit/cron-jobs/openScheduledCooperationResources.spec.js
+++ b/src/test/unit/cron-jobs/openScheduledCooperationResources.spec.js
@@ -1,0 +1,30 @@
+const cooperationService = require('~/services/cooperation')
+const { updateScheduledResources } = require('~/cron-jobs/openScheduledCooperationResources')
+
+jest.mock('~/services/cooperation', () => ({
+  openScheduledCooperationResources: jest.fn()
+}))
+
+Object.defineProperty(global, 'performance', {
+  writable: true
+})
+
+const mockedCurrentDate = new Date(2024, 12, 23, 0, 0, 0, 0)
+
+describe('openScheduledCooperationResources cron-job', () => {
+  beforeEach(() => {
+    jest.useFakeTimers('modern').setSystemTime(mockedCurrentDate)
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  it('should update scheduled resources if open from date is less or equal than the current date', async () => {
+    await updateScheduledResources()
+
+    expect(cooperationService.openScheduledCooperationResources).toHaveBeenCalledTimes(1)
+    expect(cooperationService.openScheduledCooperationResources).toHaveBeenCalledWith(mockedCurrentDate)
+  })
+})

--- a/src/test/unit/cron-jobs/scheduledCronJobs.spec.js
+++ b/src/test/unit/cron-jobs/scheduledCronJobs.spec.js
@@ -1,9 +1,13 @@
 const { checkUsersForLastLogin } = require('~/cron-jobs/checkForLastLogin')
 const { removeUnverifiedUsers } = require('~/cron-jobs/removeUnverifiedUsers')
+const { openScheduledCooperationResources } = require('~/cron-jobs/openScheduledCooperationResources')
 const scheduledCronJobs = require('~/cron-jobs/scheduledCronJobs')
 
 jest.mock('~/cron-jobs/checkForLastLogin', () => ({ checkUsersForLastLogin: { start: jest.fn() } }))
 jest.mock('~/cron-jobs/removeUnverifiedUsers', () => ({ removeUnverifiedUsers: { start: jest.fn() } }))
+jest.mock('~/cron-jobs/openScheduledCooperationResources', () => ({
+  openScheduledCooperationResources: { start: jest.fn() }
+}))
 
 describe('scheduledCronJobs', () => {
   it('should call all the cron jobs', () => {
@@ -11,5 +15,6 @@ describe('scheduledCronJobs', () => {
 
     expect(removeUnverifiedUsers.start).toHaveBeenCalled()
     expect(checkUsersForLastLogin.start).toHaveBeenCalled()
+    expect(openScheduledCooperationResources.start).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Added Cron Job that runs every midnight to check and update scheduled resources (have `openFrom` status and non-null `date`).

Before running the cron job:
![image](https://github.com/user-attachments/assets/c9441562-7e60-42d1-ba2c-5e0fefa6f8f1)

After running the cron job:
![image](https://github.com/user-attachments/assets/df7cf4fa-1201-43b1-8b5f-52f1e59cb90c)
