### PR TITLE
Created a migration for attachments

### DIFF
--- a/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.js
+++ b/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.js
@@ -25,7 +25,7 @@ module.exports = {
     )
     await attachmentsCollection.updateMany(
       { resourceType: { $exists: true } },
-      { $unset: { resourceType: 'attachment' } }
+      { $unset: { resourceType: 'attachments' } }
     )
   }
 }

--- a/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.js
+++ b/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.js
@@ -1,0 +1,28 @@
+module.exports = {
+  async up(db) {
+    const attachmentsCollection = db.collection('attachments')
+    await attachmentsCollection.updateMany({ availability: { $exists: true } }, { $unset: { availability: '' } })
+    await attachmentsCollection.updateMany(
+      { resourceType: { $exists: false } },
+      { $set: { resourceType: 'attachment' } }
+    )
+
+    await attachmentsCollection.updateMany({ resourceType: 'attachments' }, { $set: { resourceType: 'attachment' } })
+  },
+
+  async down(db) {
+    const attachmentsCollection = db.collection('attachments')
+    await attachmentsCollection.updateMany(
+      { availability: { $exists: false } },
+      {
+        $set: {
+          availability: {
+            status: 'open',
+            date: null
+          }
+        }
+      }
+    )
+    await attachmentsCollection.updateMany({ resourceType: { $exists: true } }, { $unset: { resourceType: '' } })
+  }
+}

--- a/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.js
+++ b/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.js
@@ -23,6 +23,9 @@ module.exports = {
         }
       }
     )
-    await attachmentsCollection.updateMany({ resourceType: { $exists: true } }, { $unset: { resourceType: '' } })
+    await attachmentsCollection.updateMany(
+      { resourceType: { $exists: true } },
+      { $unset: { resourceType: 'attachment' } }
+    )
   }
 }

--- a/src/test/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.spec.js
+++ b/src/test/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.spec.js
@@ -18,11 +18,11 @@ describe('20241222143712-add-resource-type-delete-availability-in-attachments', 
     client = new MongoClient(url)
     await client.connect()
     database = client.db(databaseName)
-    database.collection(collectionName).deleteMany({})
+    await database.collection(collectionName).deleteMany({})
   })
 
   afterAll(async () => {
-    database.collection(collectionName).deleteMany({})
+    await database.collection(collectionName).deleteMany({})
     await client.close()
   })
 

--- a/src/test/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.spec.js
+++ b/src/test/migrations/20241222143712-add-resource-type-delete-availability-in-attachments.spec.js
@@ -1,0 +1,103 @@
+const { MongoClient, ObjectId } = require('mongodb')
+const { up, down } = require('@root/migrations/20241222143712-add-resource-type-delete-availability-in-attachments')
+
+require('~/initialization/envSetup')
+const {
+  config: { MONGODB_URL }
+} = require('~/configs/config')
+
+const collectionName = 'attachments'
+
+const url = MONGODB_URL.slice(0, MONGODB_URL.lastIndexOf('/'))
+const databaseName = MONGODB_URL.slice(MONGODB_URL.lastIndexOf('/') + 1)
+
+describe('20241222143712-add-resource-type-delete-availability-in-attachments', () => {
+  let client, database
+
+  beforeAll(async () => {
+    client = new MongoClient(url)
+    await client.connect()
+    database = client.db(databaseName)
+    database.collection(collectionName).deleteMany({})
+  })
+
+  afterAll(async () => {
+    database.collection(collectionName).deleteMany({})
+    await client.close()
+  })
+
+  test('should remove availability field when it exists', async () => {
+    const testId = new ObjectId()
+    const testDocument = {
+      _id: testId,
+      availability: { status: 'open', date: null }
+    }
+    await database.collection(collectionName).insertOne(testDocument)
+
+    const resultBefore = await database.collection(collectionName).findOne({ _id: testId })
+    expect(resultBefore).toStrictEqual(testDocument)
+
+    await up(database)
+
+    const resultAfter = await database.collection(collectionName).findOne({ availability: { $exists: true } })
+    expect(resultAfter).toBeNull()
+  })
+
+  test('should set resourceType when it is missing', async () => {
+    const testId = new ObjectId()
+    const testDocument = {
+      _id: testId
+    }
+    await database.collection(collectionName).insertOne(testDocument)
+
+    await up(database)
+
+    const resultAfter = await database.collection(collectionName).findOne({ _id: testId })
+    expect(resultAfter.resourceType).toBe('attachment')
+  })
+
+  test('should not add resourceType if already exists', async () => {
+    const testId = new ObjectId()
+    const testDocument = {
+      _id: testId,
+      resourceType: 'attachments'
+    }
+    await database.collection(collectionName).insertOne(testDocument)
+
+    await up(database)
+
+    const resultAfter = await database.collection(collectionName).findOne({ _id: testId })
+    expect(resultAfter.resourceType).toBe('attachment')
+  })
+
+  test('should set availability field back when rolling back migration', async () => {
+    const testId = new ObjectId()
+    const testDocument = {
+      _id: testId,
+      resourceType: 'attachments'
+    }
+    await database.collection(collectionName).insertOne(testDocument)
+
+    await down(database)
+
+    const resultAfterDown = await database.collection(collectionName).findOne({ _id: testId })
+    expect(resultAfterDown.availability).toEqual({
+      status: 'open',
+      date: null
+    })
+  })
+
+  test('should remove resourceType field when rolling back migration', async () => {
+    const testId = new ObjectId()
+    const testDocument = {
+      _id: testId,
+      resourceType: 'attachments'
+    }
+    await database.collection(collectionName).insertOne(testDocument)
+
+    await down(database)
+
+    const resultAfterDownResourceType = await database.collection(collectionName).findOne({ _id: testId })
+    expect(resultAfterDownResourceType.resourceType).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Added the resourceType field to documents in the attachments collection where it did not exist.
Removed the availability field from the attachments collection.
Changed the resourceType value from attachments to attachment according to the values ​​in RESOURCES_TYPES_ENUM

**Before**
![image](https://github.com/user-attachments/assets/02ff840b-1c01-47ff-ad4a-f7b9d604fe3b)

**After**
![image](https://github.com/user-attachments/assets/c901c841-51a7-4ece-92ec-38dd9845febe)
