### PR TITLE
Validation is added or a request the has been made by the superadmin

### DIFF
--- a/src/consts/validation.js
+++ b/src/consts/validation.js
@@ -17,7 +17,7 @@ const enums = {
   SPOKEN_LANG_ENUM: ['English', 'Ukrainian', 'Polish', 'German', 'French', 'Spanish', 'Arabic'],
   PROFICIENCY_LEVEL_ENUM: ['Beginner', 'Intermediate', 'Advanced', 'Test Preparation', 'Professional', 'Specialized'],
   ROLE_ENUM: ['student', 'tutor', 'admin', 'superadmin'],
-  LOGIN_ROLE_ENUM: ['student', 'tutor', 'admin'],
+  LOGIN_ROLE_ENUM: ['student', 'tutor', 'admin', 'superadmin'],
   MAIN_ROLE_ENUM: ['student', 'tutor'],
   STATUS_ENUM: ['active', 'blocked', 'deactivated'],
   COOPERATION_STATUS_ENUM: ['pending', 'active', 'declined', 'closed', 'request to close'],

--- a/src/routes/adminInvitation.js
+++ b/src/routes/adminInvitation.js
@@ -4,13 +4,13 @@ const langMiddleware = require('~/middlewares/appLanguage')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
 const { authMiddleware, restrictTo } = require('~/middlewares/auth')
 const {
-  roles: { ADMIN }
+  roles: { SUPERADMIN }
 } = require('~/consts/auth')
 
 const adminInvitationController = require('~/controllers/adminInvitation')
 router.use(authMiddleware)
 
-router.use(restrictTo(ADMIN))
+router.use(restrictTo(SUPERADMIN))
 router.post('/', langMiddleware, asyncWrapper(adminInvitationController.sendAdminInvitations))
 router.get('/', asyncWrapper(adminInvitationController.getAdminInvitations))
 

--- a/src/routes/adminInvitation.js
+++ b/src/routes/adminInvitation.js
@@ -2,9 +2,15 @@ const router = require('express').Router()
 
 const langMiddleware = require('~/middlewares/appLanguage')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
+const { authMiddleware, restrictTo } = require('~/middlewares/auth')
+const {
+  roles: { ADMIN }
+} = require('~/consts/auth')
 
 const adminInvitationController = require('~/controllers/adminInvitation')
+router.use(authMiddleware)
 
+router.use(restrictTo(ADMIN))
 router.post('/', langMiddleware, asyncWrapper(adminInvitationController.sendAdminInvitations))
 router.get('/', asyncWrapper(adminInvitationController.getAdminInvitations))
 

--- a/src/test/integration/controllers/adminInvitation.spec.js
+++ b/src/test/integration/controllers/adminInvitation.spec.js
@@ -1,16 +1,39 @@
 const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const testUserAuthentication = require('~/utils/testUserAuth')
 
 const emails = ['test1@gmail.com', 'test2@gmail.com']
+
+let studentUser = {
+  role: ['student'],
+  firstName: 'TestStudent',
+  lastName: 'StudentTest',
+  email: 'teststudent@gmail.com',
+  password: 'studentpassword123',
+  appLanguage: 'en',
+  isEmailConfirmed: true,
+  isFirstLogin: false,
+  lastLoginAs: 'student'
+}
+
+let superadminUser = {
+  role: ['superadmin'],
+  firstName: 'TestAdmin',
+  lastName: 'AdminTest',
+  email: 'testadmin@gmail.com',
+  password: 'supersecretpass123',
+  appLanguage: 'en',
+  isEmailConfirmed: true,
+  isFirstLogin: false,
+  lastLoginAs: 'superadmin'
+}
+
 const endpointURL = '/admin-invitations'
 
 describe('Admin invitation controller', () => {
-  let app, server, response
-  beforeAll(async () => {
-    ; ({ app, server } = await serverInit())
-  })
+  let app, server, response, accessToken
 
-  beforeEach(async () => {
-    response = await app.post(endpointURL).send({ emails }).set('Accept-Language', 'en')
+  beforeAll(async () => {
+    ;({ app, server } = await serverInit())
   })
 
   afterEach(async () => {
@@ -23,24 +46,50 @@ describe('Admin invitation controller', () => {
 
   describe('admin-invitations endpoint', () => {
     describe(`POST ${endpointURL}`, () => {
-      it('should send admin invitations', async () => {
-        expect(response.statusCode).toBe(201)
+      it('should throw FORBIDDEN (student user)', async () => {
+        accessToken = await testUserAuthentication(app, studentUser)
 
-        expect(response.body).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ email: emails[0] }),
-            expect.objectContaining({ email: emails[1] })
-          ])
-        )
+        response = await app
+          .post(endpointURL)
+          .send({ emails })
+          .set('Accept-Language', 'en')
+          .set('Cookie', `accessToken=${accessToken}`)
+
+        expect(response.statusCode).toBe(403)
+      })
+
+      it('should send admin invitations (superadmin user)', async () => {
+        accessToken = await testUserAuthentication(app, superadminUser)
+
+        response = await app
+          .post(endpointURL)
+          .send({ emails })
+          .set('Accept-Language', 'en')
+          .set('Cookie', `accessToken=${accessToken}`)
+
+        expect(response.statusCode).toBe(201)
+        expect.arrayContaining([
+          expect.objectContaining({ email: emails[0] }),
+          expect.objectContaining({ email: emails[1] })
+        ])
       })
     })
 
     describe(`GET ${endpointURL}`, () => {
-      it('should get admin invitations', async () => {
-        const { body, statusCode } = await app.get(endpointURL)
+      it('should get admin invitations (superadmin user)', async () => {
+        accessToken = await testUserAuthentication(app, superadminUser)
+        await app
+          .post(endpointURL)
+          .send({ emails })
+          .set('Accept-Language', 'en')
+          .set('Cookie', `accessToken=${accessToken}`)
+
+        const { statusCode, body } = await app
+          .get(endpointURL)
+          .set('Accept-Language', 'en')
+          .set('Cookie', `accessToken=${accessToken}`)
 
         expect(statusCode).toBe(200)
-
         expect(body).toEqual(
           expect.arrayContaining([
             expect.objectContaining({ email: emails[0] }),


### PR DESCRIPTION
Using the existing restrictTo middleware, validation was implemented for a request to send an email with an invitation to become an admin. Currently, this request can be performed only by superadmin and not by every logged in user

**Before:**
![image](https://github.com/user-attachments/assets/65be016b-9f3c-42f2-8c2a-56479a0a0b3b)

**After:**
![image](https://github.com/user-attachments/assets/9b80a2d2-c02e-456e-939e-f125cc7819d9)
