### PR TITLE
Add DELETE request validation to the endpoint `/subjects/{id}`

### DIFF
--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -2,13 +2,15 @@ const router = require('express').Router({ mergeParams: true })
 
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
-const { authMiddleware } = require('~/middlewares/auth')
+const { restrictTo, authMiddleware } = require('~/middlewares/auth')
 const isEntityValid = require('~/middlewares/entityValidation')
 
 const subjectController = require('~/controllers/subject')
 const Category = require('~/models/category')
 const Subject = require('~/models/subject')
-
+const {
+  roles: { ADMIN }
+} = require('~/consts/auth')
 const body = [{ model: Category, idName: 'category' }]
 const params = [{ model: Subject, idName: 'id' }]
 
@@ -22,6 +24,8 @@ router.get('/', asyncWrapper(subjectController.getSubjects))
 router.post('/', isEntityValid({ body }), asyncWrapper(subjectController.addSubject))
 router.get('/:id', isEntityValid({ params }), asyncWrapper(subjectController.getSubjectById))
 router.patch('/:id', isEntityValid({ params }), asyncWrapper(subjectController.updateSubject))
+
+router.use(restrictTo(ADMIN))
 router.delete('/:id', isEntityValid({ params }), asyncWrapper(subjectController.deleteSubject))
 
 module.exports = router

--- a/src/test/integration/controllers/subject.spec.js
+++ b/src/test/integration/controllers/subject.spec.js
@@ -5,14 +5,30 @@ const testUserAuthentication = require('~/utils/testUserAuth')
 const Subject = require('~/models/subject')
 const checkCategoryExistence = require('~/seed/checkCategoryExistence')
 
+const {
+  roles: { ADMIN }
+} = require('~/consts/auth')
+
 const endpointUrl = '/subjects/'
 const nonExistingSubjectId = '63cf23e07281224fbbee5958'
 
 const categoryBody = { name: 'testCategory', appearance: { color: '#F67C41', icon: 'mocked-path-to-icon' } }
 const subjectBody = { name: 'English' }
 
+let adminUser = {
+  role: [ADMIN],
+  firstName: 'TestAdmin',
+  lastName: 'AdminTest',
+  email: 'testadmin@gmail.com',
+  password: 'supersecretpass123',
+  appLanguage: 'en',
+  isEmailConfirmed: true,
+  isFirstLogin: false,
+  lastLoginAs: ADMIN
+}
+
 describe('Subject controller', () => {
-  let app, server, accessToken, testSubject
+  let app, server, testUserAccessToken, adminAccessToken, testSubject
 
   beforeAll(async () => {
     ;({ app, server } = await serverInit())
@@ -20,18 +36,18 @@ describe('Subject controller', () => {
 
   beforeEach(async () => {
     await checkCategoryExistence()
-    accessToken = await testUserAuthentication(app)
+    adminAccessToken = await testUserAuthentication(app, adminUser)
 
     const categoryResponse = await app
       .post('/categories/')
-      .set('Cookie', [`accessToken=${accessToken}`])
+      .set('Cookie', [`accessToken=${adminAccessToken}`])
       .send(categoryBody)
     const category = { _id: categoryResponse.body._id, appearance: categoryResponse.body.appearance }
     subjectBody.category = category
 
     testSubject = await app
       .post(endpointUrl)
-      .set('Cookie', [`accessToken=${accessToken}`])
+      .set('Cookie', [`accessToken=${adminAccessToken}`])
       .send(subjectBody)
   })
 
@@ -47,7 +63,7 @@ describe('Subject controller', () => {
     it('should throw DOCUMENT_ALREADY_EXISTS', async () => {
       const error = await app
         .post(endpointUrl)
-        .set('Cookie', [`accessToken=${accessToken}`])
+        .set('Cookie', [`accessToken=${adminAccessToken}`])
         .send(subjectBody)
 
       expectError(409, DOCUMENT_ALREADY_EXISTS('name'), error)
@@ -72,8 +88,11 @@ describe('Subject controller', () => {
   })
 
   describe(`GET ${endpointUrl}`, () => {
+    beforeEach(async () => {
+      testUserAccessToken = await testUserAuthentication(app)
+    })
     it('should GET all subjects', async () => {
-      const response = await app.get(endpointUrl).set('Cookie', [`accessToken=${accessToken}`])
+      const response = await app.get(endpointUrl).set('Cookie', [`accessToken=${testUserAccessToken}`])
 
       expect(response.statusCode).toBe(200)
       expect(Array.isArray(response.body.items)).toBeTruthy()
@@ -95,7 +114,9 @@ describe('Subject controller', () => {
 
   describe(`GET ${endpointUrl}:id`, () => {
     it('should get a subject by ID', async () => {
-      const response = await app.get(endpointUrl + testSubject.body._id).set('Cookie', [`accessToken=${accessToken}`])
+      const response = await app
+        .get(endpointUrl + testSubject.body._id)
+        .set('Cookie', [`accessToken=${testUserAccessToken}`])
 
       expect(response.statusCode).toBe(200)
       expect(response.body).toEqual(
@@ -114,7 +135,9 @@ describe('Subject controller', () => {
     })
 
     it('should throw DOCUMENT_NOT_FOUND', async () => {
-      const response = await app.get(endpointUrl + nonExistingSubjectId).set('Cookie', [`accessToken=${accessToken}`])
+      const response = await app
+        .get(endpointUrl + nonExistingSubjectId)
+        .set('Cookie', [`accessToken=${testUserAccessToken}`])
 
       expectError(404, DOCUMENT_NOT_FOUND([Subject.modelName]), response)
     })
@@ -124,7 +147,7 @@ describe('Subject controller', () => {
     it('should update subject by ID', async () => {
       const response = await app
         .patch(endpointUrl + testSubject.body._id)
-        .set('Cookie', [`accessToken=${accessToken}`])
+        .set('Cookie', [`accessToken=${adminAccessToken}`])
         .send({ name: 'Eng' })
 
       expect(response.statusCode).toBe(204)
@@ -133,7 +156,7 @@ describe('Subject controller', () => {
     it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app
         .patch(endpointUrl + nonExistingSubjectId)
-        .set('Cookie', [`accessToken=${accessToken}`])
+        .set('Cookie', [`accessToken=${adminAccessToken}`])
         .send({ name: 'Eng' })
 
       expectError(404, DOCUMENT_NOT_FOUND([Subject.modelName]), response)
@@ -144,7 +167,7 @@ describe('Subject controller', () => {
     it('should delete subject by ID', async () => {
       const response = await app
         .delete(endpointUrl + testSubject.body._id)
-        .set('Cookie', [`accessToken=${accessToken}`])
+        .set('Cookie', [`accessToken=${adminAccessToken}`])
 
       expect(response.statusCode).toBe(204)
     })
@@ -152,9 +175,18 @@ describe('Subject controller', () => {
     it('should throw DOCUMENT_NOT_FOUND', async () => {
       const response = await app
         .delete(endpointUrl + nonExistingSubjectId)
-        .set('Cookie', [`accessToken=${accessToken}`])
+        .set('Cookie', [`accessToken=${adminAccessToken}`])
 
       expectError(404, DOCUMENT_NOT_FOUND([Subject.modelName]), response)
+    })
+
+    it('should throw FORBIDDEN', async () => {
+      testUserAccessToken = await testUserAuthentication(app)
+      const response = await app
+        .delete(endpointUrl + testSubject.body._id)
+        .set('Cookie', [`accessToken=${testUserAccessToken}`])
+
+      expect(response.statusCode).toBe(403)
     })
   })
 })


### PR DESCRIPTION
Added DELETE request validation to the endpoint `/subjects/{id}`, wrote tests that check the correctness of validation when requesting this endpoint 
**Before:**
![image](https://github.com/user-attachments/assets/2f01bb4a-3da4-402e-833d-d2da206b140c)

**After**
![image](https://github.com/user-attachments/assets/d06dfee6-967f-4dea-8058-3394f8023fdb)
