### PR TITLE
Added PATCH request validation to the endpoint /subjects/{id}

### DIFF
--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -23,9 +23,8 @@ router.get('/names', asyncWrapper(subjectController.getNamesByCategoryId))
 router.get('/', asyncWrapper(subjectController.getSubjects))
 router.post('/', isEntityValid({ body }), asyncWrapper(subjectController.addSubject))
 router.get('/:id', isEntityValid({ params }), asyncWrapper(subjectController.getSubjectById))
-router.patch('/:id', isEntityValid({ params }), asyncWrapper(subjectController.updateSubject))
 
 router.use(restrictTo(ADMIN))
 router.delete('/:id', isEntityValid({ params }), asyncWrapper(subjectController.deleteSubject))
-
+router.patch('/:id', isEntityValid({ params }), asyncWrapper(subjectController.updateSubject))
 module.exports = router

--- a/src/test/integration/controllers/subject.spec.js
+++ b/src/test/integration/controllers/subject.spec.js
@@ -161,6 +161,14 @@ describe('Subject controller', () => {
 
       expectError(404, DOCUMENT_NOT_FOUND([Subject.modelName]), response)
     })
+    it('should throw FORBIDDEN', async () => {
+      testUserAccessToken = await testUserAuthentication(app)
+      const response = await app
+        .delete(endpointUrl + testSubject.body._id)
+        .set('Cookie', [`accessToken=${testUserAccessToken}`])
+
+      expect(response.statusCode).toBe(403)
+    })
   })
 
   describe(`DELETE ${endpointUrl}:id`, () => {


### PR DESCRIPTION
Added validation on PATCH in /subjects/{id} endpoint:

**Before:** 
Every user including usual user could update subjects 
![image](https://github.com/user-attachments/assets/05b01806-409a-4d7c-977e-b71977df4e59)

**After:** 
Only ADMIN can update subjects
![image](https://github.com/user-attachments/assets/b5bab1b7-5195-459c-8062-243441ea8e55)
![image](https://github.com/user-attachments/assets/7cc8d9e1-c47a-4d26-bc57-8ab76e6f4351)
