### PR TITLE
Fixed fields mismatch in /course endpoint in POST

### DIFF
--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -91,6 +91,12 @@ definitions:
         items:
           type: object
           properties:
+            _id:
+              type: string
+            title:
+              type: string
+            description: 
+              type: string
             resources:
               type: array
               items:
@@ -159,7 +165,6 @@ definitions:
                         type: string
                       author:
                         type: string
-                        ref: '#components/user'
                       attachments:
                         type: array
                         items:

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -91,16 +91,13 @@ definitions:
         items:
           type: object
           properties:
-            title: string
-            description: string
             resources:
               type: array
               items:
                 type: object
                 properties:
                   resource:
-                    type: object
-                    additionalProperties: true
+                    type: string
                   resourceType:
                     type: string
                     enum:
@@ -120,9 +117,6 @@ definitions:
         type: string
       description:
         type: string
-      author:
-        type: string
-        ref: '#components/user'
       category:
         type: string
         ref: '#components/category'
@@ -145,22 +139,59 @@ definitions:
         items:
           type: object
           properties:
-          title: string
-          description: string
-          resources:
-            type: array
-            items:
-              type: object
-              properties:
-                resource:
-                  type: object
-                  additionalProperties: true
-                resourceType:
-                  type: string
-                  enum:
-                    - lesson
-                    - quiz
-                    - attachment
+            title:
+              type: string
+            description:
+              type: string
+            resources:
+              type: array
+              items:
+                type: object
+                properties:
+                  resource:
+                    type: object
+                    properties:
+                      title:
+                        type: string
+                      description:
+                        type: string
+                      content:
+                        type: string
+                      author:
+                        type: string
+                        ref: '#components/user'
+                      attachments:
+                        type: array
+                        items:
+                          type: string
+                      category:
+                        type: object
+                        properties:
+                          _id:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                          - _id
+                          - name
+                      _id:
+                        type: string
+                    required:
+                      - title
+                      - description
+                      - content
+                      - author
+                      - _id
+                  resourceType:
+                    type: string
+                    enum:
+                      - lesson
+                      - quiz
+                      - attachment
+          required:
+            - title
+            - description
+            - resources
     required:
       - title
       - description

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -141,7 +141,6 @@ paths:
             example:
               title: Advanced English
               description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
-              author: 63da8767c9ad4c9a0b0eacd3
               category: 64884f33fdc2d1a130c24ac2
               subject: 6488509cfdc2d1a130c24ae4
               proficiencyLevel: [Advanced]
@@ -184,16 +183,7 @@ paths:
                     resources:
                       [
                         {
-                          resource:
-                            {
-                              title: Colors in English,
-                              description: With this lesson you will learn all about colors in English.,
-                              content: <h1>Title</h1>,
-                              author: 63da8767c9ad4c9a0b0eacd3,
-                              attachments: [63ed1cd25e9d781cdb6a6b15],
-                              category: { _id: 6477007a6fa4d05e1a800ce1, name: Languages },
-                              _id: 63ed1cd25e9d781cdb6a6b17
-                            },
+                          resource: 63ed1cd25e9d781cdb6a6b17,
                           resourceType: lesson
                         }
                       ]

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -178,7 +178,8 @@ paths:
                 subject: 6488509cfdc2d1a130c24ae4
                 proficiencyLevel: [Advanced]
                 sections:
-                  - title: Section First
+                  - _id: 6781349b8c7432471f221116
+                    title: Section First
                     description: some description
                     resources:
                       [


### PR DESCRIPTION
Fixed fields mismatch in POST method in /course endpoint.
Before: 
![image](https://github.com/user-attachments/assets/be7077fc-3048-4deb-82ee-905ef4d880a1)
After:
Rewrited courseBody schema
![image](https://github.com/user-attachments/assets/95937ce0-b33c-4937-9796-7a3322eae8f7)

Also removed mismatch between actual response and example 201 response:
Actual response:
![image](https://github.com/user-attachments/assets/42debad9-c34c-4469-b566-99b2a1b4c228)

Example Response:
![image](https://github.com/user-attachments/assets/33337ac3-6d06-4233-bec3-0a8b814ac30b)

And according to changed example 201 response
![image](https://github.com/user-attachments/assets/f548d736-0ba9-48d9-b250-33a7b5604e1e)

