### PR TITLE
Removed chats with invalid users

### DIFF
--- a/migrations/20241230103249-remove-chats-with-invalid-users.js
+++ b/migrations/20241230103249-remove-chats-with-invalid-users.js
@@ -4,14 +4,14 @@ module.exports = {
       .collection('users')
       .find({}, { projection: { _id: 1 } })
       .toArray()
-    const allUserIds = allUsers.map((user) => user._id.toString())
+    const validUserIds = allUsers.map((user) => user._id.toString())
 
     const chats = await db.collection('chats').find({}).toArray()
 
     for (const chat of chats) {
-      const invalidMembers = chat.members.filter((member) => !allUserIds.includes(member.user.toString()))
+      const validMembers = chat.members.filter((member) => validUserIds.includes(member.user.toString()))
 
-      if (invalidMembers.length > 0) {
+      if (validMembers.length !== 2) {
         await db.collection('chats').deleteOne({ _id: chat._id })
       }
     }

--- a/migrations/20241230103249-remove-chats-with-invalid-users.js
+++ b/migrations/20241230103249-remove-chats-with-invalid-users.js
@@ -1,0 +1,21 @@
+module.exports = {
+  async up(db) {
+    const allUsers = await db
+      .collection('users')
+      .find({}, { projection: { _id: 1 } })
+      .toArray()
+    const allUserIds = allUsers.map((user) => user._id.toString())
+
+    const chats = await db.collection('chats').find({}).toArray()
+
+    for (const chat of chats) {
+      const invalidMembers = chat.members.filter((member) => !allUserIds.includes(member.user.toString()))
+
+      if (invalidMembers.length > 0) {
+        await db.collection('chats').deleteOne({ _id: chat._id })
+      }
+    }
+  },
+
+  async down() {}
+}

--- a/src/test/migrations/20241230103249-remove-chats-with-invalid-users.spec.js
+++ b/src/test/migrations/20241230103249-remove-chats-with-invalid-users.spec.js
@@ -1,0 +1,70 @@
+const mongoose = require('mongoose')
+const Chats = require('~/models/chat')
+const Users = require('~/models/user')
+const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const migration = require('@root/migrations/20241230103249-remove-chats-with-invalid-users')
+
+describe('Migration - Remove chats with invalid members', () => {
+  let server
+
+  beforeAll(async () => {
+    ;({ server } = await serverInit())
+  })
+
+  afterEach(async () => {
+    await serverCleanup()
+  })
+
+  afterAll(async () => {
+    await stopServer(server)
+  })
+
+  const insertUsers = async (data) => {
+    await Users.insertMany(data)
+  }
+
+  const insertChats = async (data) => {
+    await Chats.insertMany(data)
+  }
+
+  const getChats = async () => {
+    return Chats.find({}).lean()
+  }
+
+  it('Should remove chats with invalid members', async () => {
+    const validUser = new mongoose.Types.ObjectId()
+    const invalidUserId = new mongoose.Types.ObjectId()
+
+    await insertUsers([
+      {
+        _id: validUser,
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe@example.com',
+        password: 'securepassword123'
+      }
+    ])
+
+    const validChat = {
+      _id: new mongoose.Types.ObjectId(),
+      members: [{ user: validUser, role: 'student' }]
+    }
+
+    const invalidChat = {
+      _id: new mongoose.Types.ObjectId(),
+      members: [{ user: invalidUserId, role: 'tutor' }]
+    }
+
+    await insertChats([validChat, invalidChat])
+
+    await migration.up(mongoose.connection.db)
+
+    const remainingChats = await getChats()
+    expect(remainingChats).toHaveLength(1)
+    expect(remainingChats[0]._id.toString()).toBe(validChat._id.toString())
+  })
+
+  it('Should do nothing in the down migration', async () => {
+    await expect(migration.down(mongoose.connection.db)).resolves.not.toThrow()
+  })
+})

--- a/src/test/migrations/20241230103249-remove-chats-with-invalid-users.spec.js
+++ b/src/test/migrations/20241230103249-remove-chats-with-invalid-users.spec.js
@@ -31,35 +31,55 @@ describe('Migration - Remove chats with invalid members', () => {
     return Chats.find({}).lean()
   }
 
-  it('Should remove chats with invalid members', async () => {
-    const validUser = new mongoose.Types.ObjectId()
+  it('Should remove chats with invalid members or incorrect member count', async () => {
+    const validUser1 = new mongoose.Types.ObjectId()
+    const validUser2 = new mongoose.Types.ObjectId()
     const invalidUserId = new mongoose.Types.ObjectId()
 
     await insertUsers([
       {
-        _id: validUser,
-        firstName: 'John',
-        lastName: 'Doe',
-        email: 'john.doe@example.com',
-        password: 'securepassword123'
+        _id: validUser1,
+        firstName: 'Mike',
+        lastName: 'Popovych',
+        email: 'volt@example.com',
+        password: 'password1'
+      },
+      {
+        _id: validUser2,
+        firstName: 'Tony',
+        lastName: 'Stark',
+        email: 'stark@example.com',
+        password: 'password2'
       }
     ])
 
     const validChat = {
       _id: new mongoose.Types.ObjectId(),
-      members: [{ user: validUser, role: 'student' }]
+      members: [
+        { user: validUser1, role: 'student' },
+        { user: validUser2, role: 'tutor' }
+      ]
     }
 
-    const invalidChat = {
+    const invalidChatWithInvalidUser = {
       _id: new mongoose.Types.ObjectId(),
-      members: [{ user: invalidUserId, role: 'tutor' }]
+      members: [
+        { user: validUser1, role: 'student' },
+        { user: invalidUserId, role: 'tutor' }
+      ]
     }
 
-    await insertChats([validChat, invalidChat])
+    const invalidChatWithSingleMember = {
+      _id: new mongoose.Types.ObjectId(),
+      members: [{ user: validUser1, role: 'student' }]
+    }
+
+    await insertChats([validChat, invalidChatWithInvalidUser, invalidChatWithSingleMember])
 
     await migration.up(mongoose.connection.db)
 
     const remainingChats = await getChats()
+
     expect(remainingChats).toHaveLength(1)
     expect(remainingChats[0]._id.toString()).toBe(validChat._id.toString())
   })


### PR DESCRIPTION

### Summary:
This pull request introduces a database migration script to clean up the `chats` collection by removing chats that contain invalid members. The migration ensures data integrity by validating member `user` IDs against the existing `users` collection.

### Changes Introduced:

#### Migration Script (`up` method):
- Fetches all valid user IDs from the `users` collection.
- Iterates through all chats in the `chats` collection.
- Filters out invalid members whose `user` ID is not present in the list of valid user IDs.
- Deletes chats where the number of valid members is not equal to 2.

#### Rollback (`down` method):
- No rollback is implemented, as the operation involves permanent deletion of invalid data.