### PR TITLE
Added safe tests for Notification model

### DIFF
--- a/src/test/integration/models/notification.spec.js
+++ b/src/test/integration/models/notification.spec.js
@@ -1,0 +1,81 @@
+const { setupTestServer, stopServer } = require('~/test/setupSafeTest')
+
+const {
+  enums: { ROLE_ENUM, NOTIFICATION_TYPE_ENUM }
+} = require('~/consts/validation')
+
+const User = require('~/models/user')
+const Notification = require('~/models/notification')
+
+const notificationFields = ['user', 'userRole', 'reference', 'referenceModel', 'createdAt', 'updatedAt', '_id']
+
+describe('Notification model', () => {
+  let server
+
+  beforeAll(async () => {
+    const setup = await setupTestServer()
+    server = setup.server
+  })
+
+  afterAll(async () => {
+    await stopServer(server)
+  })
+
+  it('should have all required fields', async () => {
+    const fields = await Notification.find({})
+
+    for (const field of fields) {
+      notificationFields.forEach((notificationField) => {
+        expect(field).toHaveProperty(notificationField)
+      })
+    }
+  })
+
+  it('should have valid fields data types', async () => {
+    const notifications = await Notification.find({})
+
+    for (const notification of notifications) {
+      expect(typeof notification.user).toBe('object')
+      expect(typeof notification.userRole).toBe('string')
+      expect(typeof notification.type).toBe('string')
+      expect(typeof notification.reference).toBe('object')
+      expect(typeof notification.referenceModel).toBe('string')
+      expect(notification.createdAt).toBeInstanceOf(Date)
+      expect(notification.updatedAt).toBeInstanceOf(Date)
+    }
+  })
+
+  it('should have valid user references', async () => {
+    const notifications = await Notification.find({}).select({ user: true }).populate('user')
+
+    for (const notification of notifications) {
+      expect(notification.user).not.toBeNull()
+      expect(notification.user).toBeInstanceOf(User)
+    }
+  })
+
+  it('should have non-null required fields', async () => {
+    const notifications = await Notification.find({}).select({
+      user: true,
+      userRole: true,
+      reference: true,
+      referenceModel: true
+    })
+
+    for (const notification of notifications) {
+      expect(notification.user).not.toBeNull()
+      expect(notification.userRole).not.toBeNull()
+      expect(notification.reference).not.toBeNull()
+      expect(notification.referenceModel).not.toBeNull()
+    }
+  })
+
+  it('should have valid enum values', async () => {
+    const notifications = await Notification.find({}).select({ userRole: true, type: true })
+
+    for (const notification of notifications) {
+      expect(ROLE_ENUM).toContain(notification.userRole)
+      expect(NOTIFICATION_TYPE_ENUM).toContain(notification.type)
+    }
+  })
+})

--- a/src/test/integration/models/notification.spec.js
+++ b/src/test/integration/models/notification.spec.js
@@ -49,7 +49,6 @@ describe('Notification model', () => {
     const notifications = await Notification.find({}).select({ user: true }).populate('user')
 
     for (const notification of notifications) {
-      expect(notification.user).not.toBeNull()
       expect(notification.user).toBeInstanceOf(User)
     }
   })


### PR DESCRIPTION
## Description

Created a suite of **safe tests** for the `Notification` model to ensure data integrity and proper validation for the schema. These tests will run in **read-only** mode to avoid modifying the production database.

---

## **Tests**
1. Field Validation
2. Reference Validation
3. Field Constraints