### PR TITLE
Added migration to remove notifications with non-existent users

### DIFF
--- a/migrations/20250113155310-remove-notification-with-non-existent-users.js
+++ b/migrations/20250113155310-remove-notification-with-non-existent-users.js
@@ -1,0 +1,18 @@
+module.exports = {
+  async up(db) {
+    const users = await db
+      .collection('users')
+      .find({}, { projection: { _id: 1 } })
+      .toArray()
+
+    const userIds = users.map((user) => user._id.toString())
+
+    const notifications = await db.collection('notifications').find({}).toArray()
+
+    for (const notification of notifications) {
+      if (!userIds.includes(notification.user.toString())) {
+        await db.collection('notifications').deleteOne({ _id: notification._id })
+      }
+    }
+  }
+}

--- a/migrations/20250113155310-remove-notification-with-non-existent-users.js
+++ b/migrations/20250113155310-remove-notification-with-non-existent-users.js
@@ -14,5 +14,7 @@ module.exports = {
         await db.collection('notifications').deleteOne({ _id: notification._id })
       }
     }
-  }
+  },
+
+  async down() {}
 }

--- a/migrations/20250113155310-remove-notification-with-non-existent-users.js
+++ b/migrations/20250113155310-remove-notification-with-non-existent-users.js
@@ -2,7 +2,7 @@ module.exports = {
   async up(db) {
     const users = await db
       .collection('users')
-      .find({}, { projection: { _id: 1 } })
+      .find({}, { projection: { _id: true } })
       .toArray()
 
     const userIds = users.map((user) => user._id.toString())

--- a/src/test/migrations/20250113155310-remove-notification-with-non-existent-users.spec.js
+++ b/src/test/migrations/20250113155310-remove-notification-with-non-existent-users.spec.js
@@ -1,0 +1,93 @@
+const mongoose = require('mongoose')
+
+const Notifications = require('~/models/notification')
+const Users = require('~/models/user')
+const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const migration = require('@root/migrations/20250113155310-remove-notification-with-non-existent-users')
+
+describe('Migration - Remove notifications with non-existent users', () => {
+  let server
+
+  beforeAll(async () => {
+    ;({ server } = await serverInit())
+  })
+
+  afterEach(async () => {
+    await serverCleanup()
+  })
+
+  afterAll(async () => {
+    await stopServer(server)
+  })
+
+  const insertUsers = async (data) => {
+    await Users.insertMany(data)
+  }
+
+  const insertNotifications = async (data) => {
+    await Notifications.insertMany(data)
+  }
+
+  const getNotifications = async () => {
+    return Notifications.find({}).lean()
+  }
+
+  it('Should remove notifications with non-existent users', async () => {
+    const existingUser1 = new mongoose.Types.ObjectId()
+    const existingUser2 = new mongoose.Types.ObjectId()
+    const ghost = new mongoose.Types.ObjectId()
+
+    await insertUsers([
+      {
+        _id: existingUser1,
+        firstName: 'Bruce',
+        lastName: 'Wayne',
+        email: 'bruceww@gmail.com',
+        password: 'wHeReIsThEdEtOnAtOr2012'
+      },
+      {
+        _id: existingUser2,
+        firstName: 'Peter',
+        lastName: 'Parker',
+        email: 'p_parker@gmail.com',
+        password: 'sPiDeYsEnSe2002'
+      }
+    ])
+
+    const existingNotification1 = {
+      _id: new mongoose.Types.ObjectId(),
+      user: existingUser1,
+      userRole: 'student',
+      type: 'active',
+      reference: new mongoose.Types.ObjectId(),
+      referenceModel: 'Cooperation'
+    }
+
+    const existingNotification2 = {
+      _id: new mongoose.Types.ObjectId(),
+      user: existingUser2,
+      userRole: 'student',
+      type: 'active',
+      reference: new mongoose.Types.ObjectId(),
+      referenceModel: 'Cooperation'
+    }
+
+    const ghostNotification = {
+      _id: new mongoose.Types.ObjectId(),
+      user: ghost,
+      userRole: 'student',
+      type: 'active',
+      reference: new mongoose.Types.ObjectId(),
+      referenceModel: 'Cooperation'
+    }
+
+    await insertNotifications([existingNotification1, existingNotification2, ghostNotification])
+
+    await migration.up(mongoose.connection.db)
+
+    const remainingNotifications = await getNotifications()
+
+    expect(remainingNotifications).toHaveLength(2)
+    expect(remainingNotifications[0]._id.toString()).toBe(existingNotification1._id.toString())
+  })
+})


### PR DESCRIPTION
There were notifications with non-existent users before:


<img width="1133" alt="Screenshot 2025-01-13 at 17 08 54" src="https://github.com/user-attachments/assets/9a069bc1-a861-4c31-8a2e-f6a9cbd08051" />


<img width="1121" alt="Screenshot 2025-01-13 at 17 09 02" src="https://github.com/user-attachments/assets/dc452936-7adc-433f-a162-0ff08ea2bbca" />


Now it's gone!🥳