### PR TITLE
add updateTotalOffers cronjob

### DIFF
--- a/src/cron-jobs/scheduledCronJobs.js
+++ b/src/cron-jobs/scheduledCronJobs.js
@@ -1,11 +1,13 @@
 const { checkUsersForLastLogin } = require('~/cron-jobs/checkForLastLogin')
 const { removeUnverifiedUsers } = require('~/cron-jobs/removeUnverifiedUsers')
 const { openScheduledCooperationResources } = require('~/cron-jobs/openScheduledCooperationResources')
+const { updateTotalOffers } = require('~/cron-jobs/updateTotalOffers')
 
 const scheduledCronJobs = () => {
   checkUsersForLastLogin.start()
   removeUnverifiedUsers.start()
   openScheduledCooperationResources.start()
+  updateTotalOffers.start()
 }
 
 module.exports = scheduledCronJobs

--- a/src/cron-jobs/updateTotalOffers.js
+++ b/src/cron-jobs/updateTotalOffers.js
@@ -1,0 +1,15 @@
+const { CronJob } = require('cron')
+const categoryService = require('~/services/category')
+const subjectService = require('~/services/subject')
+
+const EVERY_SUNDAY_MIDNIGHT = '0 0 * * 0'
+const UTC_TIME_ZONE = 'UTC'
+
+const recountTotalOffers = async () => {
+  await categoryService.recountTotalOffers()
+  await subjectService.recountTotalOffers()
+}
+
+const updateTotalOffers = new CronJob(EVERY_SUNDAY_MIDNIGHT, recountTotalOffers, null, false, UTC_TIME_ZONE)
+
+module.exports = { updateTotalOffers, recountTotalOffers }

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -2,6 +2,7 @@ const Category = require('~/models/category')
 const Offer = require('~/models/offer')
 const conditionCreator = require('~/utils/categories/conditionCreator')
 const capitalizeFirstLetter = require('~/utils/capitalizeFirstLetter')
+const recountOfferAmount = require('~/utils/offers/recountOfferAmount')
 
 const categoryService = {
   getCategories: async (pipeline) => {
@@ -42,6 +43,17 @@ const categoryService = {
     if (!minMaxPrices.length) minMaxPrices[0] = { min: 0, max: 0 }
 
     return { minPrice: minMaxPrices[0].min, maxPrice: minMaxPrices[0].max }
+  },
+
+  recountTotalOffers: async () => {
+    const categories = await Category.aggregate(recountOfferAmount('category'))
+    const categoryBulkOps = categories.map(({ _id, totalOffers }) => ({
+      updateOne: {
+        filter: { _id },
+        update: { $set: { totalOffers } }
+      }
+    }))
+    await Category.bulkWrite(categoryBulkOps)
   }
 }
 

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -1,5 +1,6 @@
 const Subject = require('~/models/subject')
 const capitalizeFirstLetter = require('~/utils/capitalizeFirstLetter')
+const recountOfferAmount = require('~/utils/offers/recountOfferAmount')
 
 const subjectService = {
   getSubjects: async ({ skip, limit, searchFilter }) => {
@@ -43,6 +44,17 @@ const subjectService = {
 
   deleteSubject: async (id) => {
     await Subject.findByIdAndRemove(id).exec()
+  },
+
+  recountTotalOffers: async () => {
+    const subjects = await Subject.aggregate(recountOfferAmount('subject'))
+    const subjectBulkOps = subjects.map(({ _id, totalOffers }) => ({
+      updateOne: {
+        filter: { _id },
+        update: { $set: { totalOffers } }
+      }
+    }))
+    await Subject.bulkWrite(subjectBulkOps)
   }
 }
 

--- a/src/test/unit/cron-jobs/scheduledCronJobs.spec.js
+++ b/src/test/unit/cron-jobs/scheduledCronJobs.spec.js
@@ -1,6 +1,8 @@
 const { checkUsersForLastLogin } = require('~/cron-jobs/checkForLastLogin')
 const { removeUnverifiedUsers } = require('~/cron-jobs/removeUnverifiedUsers')
 const { openScheduledCooperationResources } = require('~/cron-jobs/openScheduledCooperationResources')
+const { updateTotalOffers } = require('~/cron-jobs/updateTotalOffers')
+
 const scheduledCronJobs = require('~/cron-jobs/scheduledCronJobs')
 
 jest.mock('~/cron-jobs/checkForLastLogin', () => ({ checkUsersForLastLogin: { start: jest.fn() } }))
@@ -8,6 +10,7 @@ jest.mock('~/cron-jobs/removeUnverifiedUsers', () => ({ removeUnverifiedUsers: {
 jest.mock('~/cron-jobs/openScheduledCooperationResources', () => ({
   openScheduledCooperationResources: { start: jest.fn() }
 }))
+jest.mock('~/cron-jobs/updateTotalOffers', () => ({ updateTotalOffers: { start: jest.fn() } }))
 
 describe('scheduledCronJobs', () => {
   it('should call all the cron jobs', () => {
@@ -16,5 +19,6 @@ describe('scheduledCronJobs', () => {
     expect(removeUnverifiedUsers.start).toHaveBeenCalled()
     expect(checkUsersForLastLogin.start).toHaveBeenCalled()
     expect(openScheduledCooperationResources.start).toHaveBeenCalled()
+    expect(updateTotalOffers.start).toHaveBeenCalled()
   })
 })

--- a/src/test/unit/cron-jobs/updateTotalOffers.spec.js
+++ b/src/test/unit/cron-jobs/updateTotalOffers.spec.js
@@ -1,7 +1,6 @@
 const { recountTotalOffers } = require('~/cron-jobs/updateTotalOffers')
 const categoryService = require('~/services/category')
 const subjectService = require('~/services/subject')
-// const recountOfferAmount = require('~/src/utils/offers/recountOfferAmount')
 
 jest.mock('~/services/category', () => ({
   recountTotalOffers: jest.fn()

--- a/src/test/unit/cron-jobs/updateTotalOffers.spec.js
+++ b/src/test/unit/cron-jobs/updateTotalOffers.spec.js
@@ -1,0 +1,30 @@
+const { recountTotalOffers } = require('~/cron-jobs/updateTotalOffers')
+const categoryService = require('~/services/category')
+const subjectService = require('~/services/subject')
+// const recountOfferAmount = require('~/src/utils/offers/recountOfferAmount')
+
+jest.mock('~/services/category', () => ({
+  recountTotalOffers: jest.fn()
+}))
+
+jest.mock('~/services/subject', () => ({
+  recountTotalOffers: jest.fn()
+}))
+
+describe('updateTotalOffers Cron Job', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call categoryService recountTotalOffers function', async () => {
+    await recountTotalOffers()
+
+    expect(categoryService.recountTotalOffers).toBeCalledTimes(1)
+  })
+
+  it('should call subjectService recountTotalOffers function', async () => {
+    await recountTotalOffers()
+
+    expect(subjectService.recountTotalOffers).toBeCalledTimes(1)
+  })
+})

--- a/src/test/unit/services/category.spec.js
+++ b/src/test/unit/services/category.spec.js
@@ -14,12 +14,14 @@ describe('recountTotalOffers', () => {
   it('should call Category.aggregate', async () => {
     Category.aggregate.mockResolvedValue([{ _id: 1, totalOffers: 5 }])
     await categoryService.recountTotalOffers()
+
     expect(Category.aggregate).toHaveBeenCalled()
   })
 
   it('should call Category.bulkWrite', async () => {
     Category.aggregate.mockResolvedValue([{ _id: 1, totalOffers: 5 }])
     await categoryService.recountTotalOffers()
+
     expect(Category.bulkWrite).toHaveBeenCalledWith([
       { updateOne: { filter: { _id: 1 }, update: { $set: { totalOffers: 5 } } } }
     ])

--- a/src/test/unit/services/category.spec.js
+++ b/src/test/unit/services/category.spec.js
@@ -1,0 +1,27 @@
+const categoryService = require('~/services/category.js')
+const Category = require('~/models/category')
+
+jest.mock('~/models/category', () => ({
+  aggregate: jest.fn(),
+  bulkWrite: jest.fn()
+}))
+
+describe('recountTotalOffers', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call Category.aggregate', async () => {
+    Category.aggregate.mockResolvedValue([{ _id: 1, totalOffers: 5 }])
+    await categoryService.recountTotalOffers()
+    expect(Category.aggregate).toHaveBeenCalled()
+  })
+
+  it('should call Category.bulkWrite', async () => {
+    Category.aggregate.mockResolvedValue([{ _id: 1, totalOffers: 5 }])
+    await categoryService.recountTotalOffers()
+    expect(Category.bulkWrite).toHaveBeenCalledWith([
+      { updateOne: { filter: { _id: 1 }, update: { $set: { totalOffers: 5 } } } }
+    ])
+  })
+})

--- a/src/test/unit/services/subject.spec.js
+++ b/src/test/unit/services/subject.spec.js
@@ -14,12 +14,14 @@ describe('recountTotalOffers', () => {
   it('should call Subject.aggregate', async () => {
     Subject.aggregate.mockResolvedValue([{ _id: 1, totalOffers: 5 }])
     await subjectService.recountTotalOffers()
+
     expect(Subject.aggregate).toHaveBeenCalled()
   })
 
   it('should call Subject.bulkWrite', async () => {
     Subject.aggregate.mockResolvedValue([{ _id: 1, totalOffers: 5 }])
     await subjectService.recountTotalOffers()
+
     expect(Subject.bulkWrite).toHaveBeenCalledWith([
       { updateOne: { filter: { _id: 1 }, update: { $set: { totalOffers: 5 } } } }
     ])

--- a/src/test/unit/services/subject.spec.js
+++ b/src/test/unit/services/subject.spec.js
@@ -1,0 +1,27 @@
+const subjectService = require('~/services/subject.js')
+const Subject = require('~/models/subject')
+
+jest.mock('~/models/subject', () => ({
+  aggregate: jest.fn(),
+  bulkWrite: jest.fn()
+}))
+
+describe('recountTotalOffers', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call Subject.aggregate', async () => {
+    Subject.aggregate.mockResolvedValue([{ _id: 1, totalOffers: 5 }])
+    await subjectService.recountTotalOffers()
+    expect(Subject.aggregate).toHaveBeenCalled()
+  })
+
+  it('should call Subject.bulkWrite', async () => {
+    Subject.aggregate.mockResolvedValue([{ _id: 1, totalOffers: 5 }])
+    await subjectService.recountTotalOffers()
+    expect(Subject.bulkWrite).toHaveBeenCalledWith([
+      { updateOne: { filter: { _id: 1 }, update: { $set: { totalOffers: 5 } } } }
+    ])
+  })
+})

--- a/src/utils/offers/recountOfferAmount.js
+++ b/src/utils/offers/recountOfferAmount.js
@@ -1,0 +1,45 @@
+const recountOfferAmount = (model) => {
+  return [
+    {
+      $lookup: {
+        from: 'offers',
+        localField: '_id',
+        foreignField: model,
+        as: 'offers'
+      }
+    },
+    {
+      $set: {
+        totalOffers: {
+          student: {
+            $size: {
+              $filter: {
+                input: '$offers',
+                as: 'offer',
+                cond: {
+                  $and: [{ $eq: ['$$offer.status', 'active'] }, { $eq: ['$$offer.authorRole', 'student'] }]
+                }
+              }
+            }
+          },
+          tutor: {
+            $size: {
+              $filter: {
+                input: '$offers',
+                as: 'offer',
+                cond: {
+                  $and: [{ $eq: ['$$offer.status', 'active'] }, { $eq: ['$$offer.authorRole', 'tutor'] }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      $project: { _id: true, totalOffers: true }
+    }
+  ]
+}
+
+module.exports = recountOfferAmount


### PR DESCRIPTION
#1118 
On the _Home_ page, the offer count description for `subjects` and `categories` was displaying incorrect counts. For example, the _Music_ category was shown to have 20 offers, while the database contained only 11 (as seen in the screenshot below):
<img width="725" alt="Screenshot 2025-01-14 at 18 06 44" src="https://github.com/user-attachments/assets/fea386c7-aea0-44a1-a64c-2c6195d21558" />

We already have functions that update the `totalOffers` field when creating or updating offers. I tested these functions and confirmed they work correctly. However, the counts remained inaccurate.

The issue likely occurred because, during development, offers were sometimes updated directly in the database for testing purposes. These direct updates bypassed the functions responsible for recalculating the `totalOffers` field, leading to inconsistencies.

### Solution:

- created a new `utility` function that takes a model as an argument and updates the `totalOffers` field.
- new `recountTotalOffers` service functions were added to the `category` and `subject` services. These functions use the utility function to perform recalculations.
- the **cron job** function now calls these service functions to automate the recalculation process. This cron job recalculates the `totalOffers` field for all subjects and categories every Sunday at midnight, ensuring future accuracy.

After implementing the cron job, the offer counts are now displayed correctly, as seen in the updated screenshots:
<img width="194" alt="Screenshot 2025-01-14 at 18 03 30" src="https://github.com/user-attachments/assets/92131a2d-0037-4233-a36b-beec5054a293" />
<img width="600" alt="Screenshot 2025-01-14 at 18 03 41" src="https://github.com/user-attachments/assets/5ab0246c-93c1-42ce-8e14-edb57181cb40" />
<img width="608" alt="Screenshot 2025-01-14 at 19 42 16" src="https://github.com/user-attachments/assets/b950094d-2835-4abe-a6ce-cf3fbf342392" />

_____________________________________________________________________

- [x]  Created a new utility function to update the `totalOffers` field for a given model.
- [x] Added `recountTotalOffers` service functions to category and subject services, which use the new utility function.
- [x] Implemented a **cron job** to automatically recalculate the `totalOffers` field for all subjects and categories every Sunday at midnight.
- [x] Added tests to ensure the functionality works as expected
