### PR TITLE
Fixed incorrect schemas in resources categories

### DIFF
--- a/docs/resourcesCategory/resourcesCategory.schema.yaml
+++ b/docs/resourcesCategory/resourcesCategory.schema.yaml
@@ -1,5 +1,5 @@
 definitions:
-  resourceCategoryBody:
+  resourcesCategoryBody:
     type: object
     properties:
       name:
@@ -19,3 +19,21 @@ definitions:
       updatedAt:
         type: string
         format: date-time
+  resourcesCategories:
+    type: object
+    properties:
+      count:
+        type: integer
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/resourcesCategory'
+  resourcesCategoriesNames:
+    type: array
+    items:
+      type: object
+      properties:
+        _id:
+          type: string
+        name:
+          type: string

--- a/docs/resourcesCategory/resourcesCategory.yaml
+++ b/docs/resourcesCategory/resourcesCategory.yaml
@@ -36,7 +36,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/resourcesCategory'
+                $ref: '#/definitions/resourcesCategories'
               example:
                 count: 2
                 items:
@@ -79,7 +79,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/resourceCategoryBody'
+              $ref: '#/definitions/resourcesCategoryBody'
             example:
               name: Chemical Category
       responses:
@@ -132,7 +132,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/resourcesCategory'
+                $ref: '#/definitions/resourcesCategoriesNames'
               example: [{ _id: 6502ec2060ec37be943353e2, name: 'New Category 1' }]
         401:
           description: Unauthorized
@@ -176,7 +176,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/resourceCategoryBody'
+              $ref: '#/definitions/resourcesCategoryBody'
             example:
               name: Computer Science
       responses:


### PR DESCRIPTION
Example value for /resources-categories GET 200:
<img width="1226" alt="Screenshot 2025-01-15 at 12 16 47" src="https://github.com/user-attachments/assets/8f1451f5-c35a-40a8-b3f4-e8a21461db46" />


Schema for /resources-categories GET 200 before:
<img width="371" alt="Screenshot 2025-01-15 at 12 17 20" src="https://github.com/user-attachments/assets/711c3f80-93eb-461c-ba4c-d37f57353160" />


Schema for /resources-categories GET 200 after:
<img width="518" alt="Screenshot 2025-01-15 at 12 17 39" src="https://github.com/user-attachments/assets/2e7c4382-4324-41c3-a478-4ccffecf2fbf" />


Example value for /resources-categories/names GET 200:
<img width="1225" alt="Screenshot 2025-01-15 at 12 17 07" src="https://github.com/user-attachments/assets/9534bafd-393e-4569-9700-4703ac480d07" />


Schema for /resources-categories/names GET 200 before:
<img width="372" alt="Screenshot 2025-01-15 at 12 16 57" src="https://github.com/user-attachments/assets/53c5e359-36a2-488a-a195-628f5f16c384" />


Schema for /resources-categories/names GET 200 after:
<img width="315" alt="Screenshot 2025-01-15 at 12 17 59" src="https://github.com/user-attachments/assets/234b65f2-9a42-4c30-8a4f-ee98e3818049" />

