### PR TITLE
Add migrations to fix invalid references in resourcesCategories

### DIFF
--- a/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references.js
+++ b/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references.js
@@ -2,7 +2,7 @@ const { mapToId } = require('../src/utils/mapToId')
 
 module.exports = {
   async up(db) {
-    const allUsers = await db.collection('users').find({}, { _id: true }).toArray()
+    const allUsers = await db.collection('users').find({}).toArray()
     const userIds = mapToId(allUsers)
     const invalidResourcesCategories = await db
       .collection('resourcescategories')

--- a/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references.js
+++ b/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references.js
@@ -1,0 +1,18 @@
+const { mapToId } = require('../src/utils/mapToId')
+
+module.exports = {
+  async up(db) {
+    const allUsers = await db.collection('users').find({}, { _id: true }).toArray()
+    const userIds = mapToId(allUsers)
+    const invalidResourcesCategories = await db
+      .collection('resourcescategories')
+      .find({ author: { $nin: userIds } })
+      .toArray()
+
+    if (invalidResourcesCategories.length > 0) {
+      await db.collection('resourcescategories').deleteMany({ _id: { $in: mapToId(invalidResourcesCategories) } })
+    }
+  },
+
+  async down() {}
+}

--- a/src/test/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references.spec.js
+++ b/src/test/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references.spec.js
@@ -27,7 +27,6 @@ describe('20250123142314-remove-resourcescategories-with-invalid-user-references
   afterEach(async () => await serverCleanup())
 
   afterAll(async () => {
-    await migration.up(mongoose.connection.db)
     await stopServer(server)
   })
 

--- a/src/test/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references.spec.js
+++ b/src/test/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references.spec.js
@@ -1,0 +1,60 @@
+const mongoose = require('mongoose')
+const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const ResourcesCategories = require('~/models/resourcesCategory')
+
+const migration = require('@root/migrations/20250123142314-remove-resourcescategories-with-invalid-user-references')
+
+const resourcesCategories = {
+  name: 'Music'
+}
+
+const authorData = {
+  email: 'john_doe@example.com',
+  password: 'password'
+}
+
+const insertTestData = async () => {
+  const { insertedId: authorId } = await mongoose.connection.db.collection('users').insertOne(authorData)
+
+  return authorId
+}
+
+describe('20250123142314-remove-resourcescategories-with-invalid-user-references', () => {
+  let server
+
+  beforeAll(async () => ({ server } = await serverInit()))
+
+  afterEach(async () => await serverCleanup())
+
+  afterAll(async () => {
+    await migration.up(mongoose.connection.db)
+    await stopServer(server)
+  })
+
+  test('should remove resourcesCategories with invalid author references', async () => {
+    const authorId = await insertTestData()
+
+    const validResourcesCategories = {
+      ...resourcesCategories,
+      author: authorId
+    }
+
+    const invalidResourcesCategories = {
+      ...resourcesCategories,
+      author: '5f5f5f5f5f5f5f5f5f5f5f5f'
+    }
+
+    await ResourcesCategories.create(validResourcesCategories)
+    await ResourcesCategories.create(invalidResourcesCategories)
+
+    await migration.up(mongoose.connection.db)
+
+    const invalidResourcesCategoriesAfterMigration = await ResourcesCategories.find({
+      author: '5f5f5f5f5f5f5f5f5f5f5f5f'
+    })
+    const validResourcesCategoriesAfterMigration = await ResourcesCategories.find({})
+
+    expect(invalidResourcesCategoriesAfterMigration).toHaveLength(0)
+    expect(validResourcesCategoriesAfterMigration).toHaveLength(1)
+  })
+})

--- a/src/utils/mapToId.js
+++ b/src/utils/mapToId.js
@@ -1,0 +1,5 @@
+const mapToId = (items) => {
+  return items.map((item) => item._id)
+}
+
+module.exports = { mapToId }


### PR DESCRIPTION
#1155 
Introduced a new migration script to remove `resourcesCategories` with invalid references.

**Changes Made:**

1. New Migration Script:

      - Added the migration `20250123142314-remove-resourcescategories-with-invalid-user-references.`
      - The script identifies and removes `resourcesCategories` with invalid references to users in the database.

2. Utility Function:

      - Created a reusable `mapToId` utility in src/utils/mapToId.js to simplify the process of extracting `_id` values from MongoDB documents.
     
3. Test Coverage:

      - Covered the new migration script with tests.
   ------------------------------

- [x] Created migration to remove invalid cooperations.
- [x] Added mapToId utility function.
- [x] Added unit tests for migration script.