### PR TITLE
Update additionalInfo field to meet minimum length requirement in cooperations

### DIFF
--- a/migrations/20250125172611-update-cooperations-additional-info-length.js
+++ b/migrations/20250125172611-update-cooperations-additional-info-length.js
@@ -1,0 +1,27 @@
+const { mapToId } = require('../src/utils/mapToId')
+
+module.exports = {
+  async up(db) {
+    const additionalText = ' //additionalInfo needs to be greater or equal 30'
+    const invalidCooperations = await db
+      .collection('cooperation')
+      .find({
+        $and: [{ additionalInfo: { $exists: true } }, { $expr: { $lt: [{ $strLenCP: '$additionalInfo' }, 30] } }]
+      })
+      .toArray()
+
+    if (invalidCooperations.length > 0) {
+      await db.collection('cooperation').updateMany({ _id: { $in: mapToId(invalidCooperations) } }, [
+        {
+          $set: {
+            additionalInfo: {
+              $concat: ['$additionalInfo', additionalText]
+            }
+          }
+        }
+      ])
+    }
+  },
+
+  async down() {}
+}

--- a/src/test/migrations/20250125172611-update-cooperations-additional-info-length.spec.js
+++ b/src/test/migrations/20250125172611-update-cooperations-additional-info-length.spec.js
@@ -1,0 +1,62 @@
+const mongoose = require('mongoose')
+const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const Cooperation = require('~/models/cooperation')
+
+const migration = require('@root/migrations/20250125172611-update-cooperations-additional-info-length')
+
+const cooperationData = {
+  offer: '6739b6993decba1e46b66a26',
+  initiator: '5f5f5f5f5f5f5f5f5f5f5f5f',
+  initiatorRole: 'student',
+  receiver: '673615d36b214652201af558',
+  receiverRole: 'tutor',
+  proficiencyLevel: 'Beginner',
+  price: 500,
+  status: 'active',
+  needAction: 'tutor',
+  availableQuizzes: [],
+  finishedQuizzes: [],
+  sections: []
+}
+
+const validCooperation = {
+  ...cooperationData,
+  title: 'valid cooperation',
+  additionalInfo: 'this additionalInfo field length is greater that 30 characters'
+}
+
+const invalidCooperation = {
+  ...cooperationData,
+  title: 'invalid cooperation',
+  additionalInfo: 'length is less that 30 before update'
+}
+
+describe('20250125172611-update-cooperations-additional-info-length', () => {
+  let server
+
+  beforeAll(async () => ({ server } = await serverInit()))
+
+  afterEach(async () => await serverCleanup())
+
+  afterAll(async () => {
+    await stopServer(server)
+  })
+
+  test('should increase additionalInfo field length for invalid cooperations', async () => {
+    const invalidCooperationBeforeUpdate = await Cooperation.create(invalidCooperation)
+    await Cooperation.create(validCooperation)
+
+    await Cooperation.updateOne(
+      { _id: invalidCooperationBeforeUpdate._id },
+      { $set: { additionalInfo: 'less than 30' } }
+    )
+
+    await migration.up(mongoose.connection.db)
+
+    const invalidCooperationAfterMigration = await Cooperation.findOne({ title: invalidCooperation.title })
+    const validCooperationAfterMigration = await Cooperation.findOne({ title: validCooperation.title })
+
+    expect(invalidCooperationAfterMigration.additionalInfo.length).toBeGreaterThanOrEqual(30)
+    expect(validCooperationAfterMigration.additionalInfo).toBe(validCooperation.additionalInfo)
+  })
+})

--- a/src/test/migrations/20250125172611-update-cooperations-additional-info-length.spec.js
+++ b/src/test/migrations/20250125172611-update-cooperations-additional-info-length.spec.js
@@ -13,7 +13,11 @@ const cooperationData = {
   proficiencyLevel: 'Beginner',
   price: 500,
   status: 'active',
-  needAction: 'tutor',
+  needAction: {
+    role: 'student',
+    type: 'price',
+    messages: []
+  },
   availableQuizzes: [],
   finishedQuizzes: [],
   sections: []


### PR DESCRIPTION
Some `Cooperation` documents contain an `additionalInfo` field that is shorter than the required minimum of _30_ characters. Since the schema validation enforces a minimum length of 30 and a maximum of 1000 characters, this migration updates affected documents to meet the validation constraint.

**Changes:**

- Identified all `Cooperation` documents where additionalInfo is _shorter than 30 characters_.
- Updated the additionalInfo field by appending a predefined text (`//additionalInfo needs to be greater or equal 30`) to ensure compliance.
- Added _tests_ to verify that the migration correctly updates invalid documents.
- No impact on documents where additionalInfo is already valid or does not exist.
----------------------------

- [x] Created migration to update cooperation documents where additionalInfo field does not meet length requirements
- [x] Covered with tests  