### PR TITLE
Fixed incorrect field assignments in Note schema

### DIFF
--- a/docs/note/note-schema.yaml
+++ b/docs/note/note-schema.yaml
@@ -4,21 +4,7 @@ definitions:
     items:
       type: object
       properties:
-        _id:
-          type: string
-        text:
-          type: string
-        author:
-          type: string
-          ref: '#components/user'
-        isPrivate:
-          type: boolean
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
+        $ref: '#/definitions/note'
   noteBody:
     type: object
     properties:
@@ -34,13 +20,25 @@ definitions:
       text:
         type: string
       author:
-        type: string
-        ref: '#components/user'
+        $ref: '#/definitions/userInNote'
       isPrivate:
         type: boolean
+      cooperation:
+        type: string
       createdAt:
         type: string
         format: date-time
       updatedAt:
         type: string
         format: date-time
+  userInNote:
+    type: object
+    properties:
+      _id:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      photo:
+        type: string

--- a/docs/note/note-schema.yaml
+++ b/docs/note/note-schema.yaml
@@ -2,9 +2,7 @@ definitions:
   notes:
     type: array
     items:
-      type: object
-      properties:
-        $ref: '#/definitions/note'
+      $ref: '#/definitions/note'
   noteBody:
     type: object
     properties:

--- a/docs/note/note.yaml
+++ b/docs/note/note.yaml
@@ -29,6 +29,7 @@ paths:
                     _id: 64ebc6fbd2f34037d0aba294
                     firstName: Harry
                     lastName: Potter
+                    photo: img.jpg
                   isPrivate: false
                   cooperation: 63ebc6fbd2f34037d0aba699
                   createdAt: 2023-02-14T23:44:21.334Z
@@ -102,6 +103,7 @@ paths:
                   _id: 64ebc6fbd2f34037d0aba294
                   firstName: Harry
                   lastName: Potter
+                  photo: img.jpg
                 isPrivate: true
                 cooperation: 63ebc6fbd2f34037d0aba699
                 createdAt: 2023-02-14T23:44:21.334Z


### PR DESCRIPTION
#1091 
In `Note` schema:

- created `userInNote` schema and referenced it in other schemas;
- reused existing `Note` schema where needed;
- added missing fields (`cooperation`);
- updated examples.

Now updated Note schema looks like this:
<img width="428" alt="Screenshot 2025-01-28 at 00 05 54" src="https://github.com/user-attachments/assets/c2264d9a-71af-4f8d-b7fb-86504e50cd8d" />
-----------------------

- [x] updated Note schema;
- [x] updated examples.