### PR TITLE
Fix deleted resources not being removed from cooperations

### DIFF
--- a/src/consts/resourceType.js
+++ b/src/consts/resourceType.js
@@ -1,0 +1,5 @@
+const resourceType = {
+  ATTACHMENT: 'attachment'
+}
+
+module.exports = resourceType

--- a/src/consts/resourceType.js
+++ b/src/consts/resourceType.js
@@ -1,6 +1,7 @@
 const resourceType = {
   ATTACHMENT: 'attachment',
-  LESSON: 'lesson'
+  LESSON: 'lesson',
+  QUIZ: 'quiz'
 }
 
 module.exports = resourceType

--- a/src/consts/resourceType.js
+++ b/src/consts/resourceType.js
@@ -1,5 +1,6 @@
 const resourceType = {
-  ATTACHMENT: 'attachment'
+  ATTACHMENT: 'attachment',
+  LESSON: 'lesson'
 }
 
 module.exports = resourceType

--- a/src/services/attachment.js
+++ b/src/services/attachment.js
@@ -56,7 +56,7 @@ const attachmentService = {
     if (category && typeof category === 'string') {
       checkIdValidity(category)
 
-      const resourceCategoryEntity = await resourcesCategoryService.getById(category)
+      const resourceCategoryEntity = await resourcesCategoryService.getResourcesCategoryById(category)
 
       if (!resourceCategoryEntity) {
         throw createError(404, DOCUMENT_NOT_FOUND(refs.RESOURCES_CATEGORY))

--- a/src/services/attachment.js
+++ b/src/services/attachment.js
@@ -4,8 +4,11 @@ const { createForbiddenError, createError } = require('~/utils/errorsHelper')
 const uploadService = require('~/services/upload')
 const { ATTACHMENT } = require('~/consts/upload')
 const resourceType = require('~/consts/resourceType')
+const refs = require('~/consts/models')
+const checkIdValidity = require('~/utils/checkIdValidity')
 
 const cooperationService = require('./cooperation')
+const resourcesCategoryService = require('./resourcesCategory')
 
 const attachmentService = {
   getAttachments: async (match, sort, skip, limit) => {
@@ -46,7 +49,21 @@ const attachmentService = {
       throw createForbiddenError()
     }
 
-    attachment.category = category
+    if (category === null) {
+      attachment.category = category
+    }
+
+    if (category && typeof category === 'string') {
+      checkIdValidity(category)
+
+      const respurceCategoryEntity = await resourcesCategoryService.getById(category)
+
+      if (!respurceCategoryEntity) {
+        throw createError(404, DOCUMENT_NOT_FOUND(refs.RESOURCES_CATEGORY))
+      }
+
+      attachment.category = category
+    }
 
     if (fileName) {
       const [fileExtension] = attachment.fileName.split('.').reverse()

--- a/src/services/attachment.js
+++ b/src/services/attachment.js
@@ -56,9 +56,9 @@ const attachmentService = {
     if (category && typeof category === 'string') {
       checkIdValidity(category)
 
-      const respurceCategoryEntity = await resourcesCategoryService.getById(category)
+      const resourceCategoryEntity = await resourcesCategoryService.getById(category)
 
-      if (!respurceCategoryEntity) {
+      if (!resourceCategoryEntity) {
         throw createError(404, DOCUMENT_NOT_FOUND(refs.RESOURCES_CATEGORY))
       }
 

--- a/src/services/attachment.js
+++ b/src/services/attachment.js
@@ -3,6 +3,9 @@ const Attachment = require('~/models/attachment')
 const { createForbiddenError, createError } = require('~/utils/errorsHelper')
 const uploadService = require('~/services/upload')
 const { ATTACHMENT } = require('~/consts/upload')
+const resourceType = require('~/consts/resourceType')
+
+const cooperationService = require('./cooperation')
 
 const attachmentService = {
   getAttachments: async (match, sort, skip, limit) => {
@@ -76,7 +79,9 @@ const attachmentService = {
       throw createForbiddenError()
     }
 
-    await Attachment.findByIdAndRemove(id).exec()
+    await cooperationService.removeResourceFromCooperations(id, resourceType.ATTACHMENT, currentUser)
+
+    await Attachment.findByIdAndRemove(id)
   }
 }
 

--- a/src/services/attachment.js
+++ b/src/services/attachment.js
@@ -58,7 +58,7 @@ const attachmentService = {
       attachment.link = newLink
     }
 
-    if (description) {
+    if (description !== undefined) {
       attachment.description = description
     }
 

--- a/src/services/cooperation.js
+++ b/src/services/cooperation.js
@@ -185,6 +185,17 @@ const cooperationService = {
         ]
       }
     )
+  },
+
+  removeResourceFromCooperations: async (resourceId, resourceType, userId) => {
+    await Cooperation.updateMany(
+      {
+        $or: [{ receiver: userId }, { initiator: userId }],
+        'sections.resources.resourceType': resourceType,
+        'sections.resources.resource': resourceId
+      },
+      { $pull: { 'sections.$[].resources': { resourceType: resourceType, resource: resourceId } } }
+    )
   }
 }
 

--- a/src/services/lesson.js
+++ b/src/services/lesson.js
@@ -1,6 +1,8 @@
 const Lesson = require('~/models/lesson')
-
 const { createForbiddenError } = require('~/utils/errorsHelper')
+const resourceType = require('~/consts/resourceType')
+
+const cooperationService = require('./cooperation')
 
 const lessonService = {
   createLesson: async (author, data) => {
@@ -52,6 +54,8 @@ const lessonService = {
     if (lessonAuthor !== currentUserId) {
       throw createForbiddenError()
     }
+
+    await cooperationService.removeResourceFromCooperations(id, resourceType.LESSON, currentUserId)
 
     await Lesson.findByIdAndRemove(id).exec()
   },

--- a/src/services/quiz.js
+++ b/src/services/quiz.js
@@ -1,5 +1,8 @@
 const Quiz = require('~/models/quiz')
 const { createForbiddenError } = require('~/utils/errorsHelper')
+const resourceType = require('~/consts/resourceType')
+
+const cooperationService = require('./cooperation')
 
 const quizService = {
   getQuiz: async (match, sort, skip = 0, limit = 10) => {
@@ -54,6 +57,7 @@ const quizService = {
 
     await quiz.save()
   },
+
   deleteQuiz: async (id, currentUserId) => {
     const quiz = await Quiz.findById(id)
 
@@ -62,6 +66,8 @@ const quizService = {
     if (quizAuthor !== currentUserId) {
       throw createForbiddenError()
     }
+
+    await cooperationService.removeResourceFromCooperations(id, resourceType.QUIZ, currentUserId)
 
     await Quiz.findByIdAndRemove(id).exec()
   }

--- a/src/services/resourcesCategory.js
+++ b/src/services/resourcesCategory.js
@@ -11,7 +11,7 @@ const resourcesCategoryService = {
     })
   },
 
-  getById: async (id) => {
+  getResourcesCategoryById: async (id) => {
     return await ResourcesCategory.findById(id).lean().exec()
   },
 

--- a/src/services/resourcesCategory.js
+++ b/src/services/resourcesCategory.js
@@ -11,6 +11,10 @@ const resourcesCategoryService = {
     })
   },
 
+  getById: async (id) => {
+    return await ResourcesCategory.findById(id).lean().exec()
+  },
+
   getResourcesCategories: async (match, sort, skip, limit) => {
     const items = await ResourcesCategory.find(match)
       .collation({ locale: 'en', strength: 1 })
@@ -22,6 +26,7 @@ const resourcesCategoryService = {
 
     return { count, items }
   },
+
   getResourcesCategoriesNames: async (match) => {
     return await ResourcesCategory.find(match).select('name').exec()
   },

--- a/src/test/integration/controllers/attachments.spec.js
+++ b/src/test/integration/controllers/attachments.spec.js
@@ -11,6 +11,9 @@ const uploadService = require('~/services/upload')
 const {
   enums: { RESOURCES_TYPES_ENUM }
 } = require('~/consts/validation')
+const resourcesCategoryService = require('~/services/resourcesCategory')
+const refs = require('~/consts/models')
+const { INVALID_ID } = require('~/consts/errors')
 
 jest.mock('@azure/storage-blob', () => {
   const mockBlockBlobClient = {
@@ -293,6 +296,51 @@ describe('Attachments controller', () => {
         .set('Cookie', [`accessToken=${accessToken}`])
 
       expectError(404, DOCUMENT_NOT_FOUND([Attachment.modelName]), response)
+    })
+
+    it('should update attachment category to null', async () => {
+      const response = await app
+        .patch(endpointUrl + testAttachmentId)
+        .send({ category: null })
+        .set('Cookie', [`accessToken=${accessToken}`])
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body.category).toBeNull()
+    })
+
+    it('should update attachment when valid existing category id is provided', async () => {
+      const category = await resourcesCategoryService.createResourcesCategory(currentUser.id, {
+        name: 'Web-development'
+      })
+
+      const response = await app
+        .patch(endpointUrl + testAttachmentId)
+        .send({ category: category._id.toString() })
+        .set('Cookie', [`accessToken=${accessToken}`])
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body.category).toEqual({
+        _id: category._id.toString(),
+        name: category.name
+      })
+    })
+
+    it('should throw DOCUMENT_NOT_FOUND when non-existent category id is provided', async () => {
+      const response = await app
+        .patch(endpointUrl + testAttachmentId)
+        .send({ category: '5f5f5f5f5f5f5f5f5f5f5f5f' })
+        .set('Cookie', [`accessToken=${accessToken}`])
+
+      expectError(404, DOCUMENT_NOT_FOUND(refs.RESOURCES_CATEGORY), response)
+    })
+
+    it('should throw INVALID_ID when invalid category id is provided', async () => {
+      const response = await app
+        .patch(endpointUrl + testAttachmentId)
+        .send({ category: 'notAnId' })
+        .set('Cookie', [`accessToken=${accessToken}`])
+
+      expectError(400, INVALID_ID, response)
     })
   })
 

--- a/src/test/integration/controllers/attachments.spec.js
+++ b/src/test/integration/controllers/attachments.spec.js
@@ -2,8 +2,11 @@ const { serverCleanup, serverInit, stopServer } = require('~/test/setup')
 const testUserAuthentication = require('~/utils/testUserAuth')
 const { expectError } = require('~/test/helpers')
 const { UNAUTHORIZED, FORBIDDEN, DOCUMENT_NOT_FOUND } = require('~/consts/errors')
+const resourceType = require('~/consts/resourceType')
+const { roles } = require('~/consts/auth')
 const TokenService = require('~/services/token')
 const Attachment = require('~/models/attachment')
+const cooperationService = require('~/services/cooperation')
 const uploadService = require('~/services/upload')
 const {
   enums: { RESOURCES_TYPES_ENUM }
@@ -305,6 +308,55 @@ describe('Attachments controller', () => {
       const response = await app.delete(endpointUrl + testAttachmentId).set('Cookie', [`accessToken=${token}`])
 
       expectError(403, FORBIDDEN, response)
+    })
+
+    it('should delete attachment and remove references from all cooperation sections', async () => {
+      const cooperationData = {
+        offer: '82a51e41de4debbccf0b3111',
+        initiator: currentUser.id,
+        initiatorRole: 'tutor',
+        receiver: '62a51e41de4debbccf0b3111',
+        receiverRole: 'student',
+        title: 'Web Development Course',
+        proficiencyLevel: 'Beginner',
+        price: 500,
+        status: 'active',
+        needAction: 'student',
+        sections: [
+          {
+            title: 'Start with HTML',
+            description: 'Learn the basics of HTML',
+            resources: [
+              {
+                resource: testAttachmentId,
+                resourceType: resourceType.ATTACHMENT
+              }
+            ]
+          },
+          {
+            title: 'Continue with CSS',
+            description: 'Learn the basics of CSS',
+            resources: [
+              {
+                resource: testAttachmentId,
+                resourceType: resourceType.ATTACHMENT
+              }
+            ]
+          }
+        ]
+      }
+
+      const cooperation = await cooperationService.createCooperation(currentUser.id, roles.TUTOR, cooperationData)
+
+      const response = await app.delete(endpointUrl + testAttachmentId).set('Cookie', [`accessToken=${accessToken}`])
+
+      const updatedCooperation = await cooperationService.getCooperationById(cooperation._id, roles.TUTOR)
+
+      expect(response.statusCode).toBe(204)
+
+      updatedCooperation.sections.forEach((section) => {
+        expect(section.resources).toHaveLength(0)
+      })
     })
   })
 })

--- a/src/test/integration/controllers/lesson.spec.js
+++ b/src/test/integration/controllers/lesson.spec.js
@@ -3,6 +3,10 @@ const testUserAuthentication = require('~/utils/testUserAuth')
 const Lesson = require('~/models/lesson')
 const { expectError } = require('~/test/helpers')
 const { UNAUTHORIZED, DOCUMENT_NOT_FOUND, FORBIDDEN } = require('~/consts/errors')
+const cooperationService = require('~/services/cooperation')
+const TokenService = require('~/services/token')
+const { roles } = require('~/consts/auth')
+const resourceType = require('~/consts/resourceType')
 
 const endpointUrl = '/lessons/'
 const nonExistingLessonId = '64a51e41de4debbccf0b39b0'
@@ -46,7 +50,7 @@ const studentUserData = {
 }
 
 describe('Lesson controller', () => {
-  let app, server, accessToken, studentAccessToken, testLessonResponse, testLessonId
+  let app, server, accessToken, studentAccessToken, testLessonResponse, testLessonId, currentUser
 
   beforeAll(async () => {
     ;({ app, server } = await serverInit())
@@ -55,6 +59,7 @@ describe('Lesson controller', () => {
   beforeEach(async () => {
     accessToken = await testUserAuthentication(app, tutorUser)
     studentAccessToken = await testUserAuthentication(app)
+    currentUser = TokenService.validateAccessToken(accessToken)
 
     testLessonResponse = await app
       .post(endpointUrl)
@@ -154,6 +159,57 @@ describe('Lesson controller', () => {
       const response = await app.delete(endpointUrl + nonExistingLessonId).set('Cookie', [`accessToken=${accessToken}`])
 
       expectError(404, DOCUMENT_NOT_FOUND([Lesson.modelName]), response)
+    })
+
+    it('should delete lesson and remove references from all cooperation sections', async () => {
+      const cooperationData = {
+        offer: '82a51e41de4debbccf0b3111',
+        initiator: currentUser.id,
+        initiatorRole: 'tutor',
+        receiver: '62a51e41de4debbccf0b3111',
+        receiverRole: 'student',
+        title: 'Web Development Course',
+        proficiencyLevel: 'Beginner',
+        price: 500,
+        status: 'active',
+        needAction: 'student',
+        sections: [
+          {
+            title: 'Start with HTML',
+            description: 'Learn the basics of HTML',
+            resources: [
+              {
+                resource: testLessonId,
+                resourceType: resourceType.LESSON
+              }
+            ]
+          },
+          {
+            title: 'Continue with CSS',
+            description: 'Learn the basics of CSS',
+            resources: [
+              {
+                resource: testLessonId,
+                resourceType: resourceType.LESSON
+              }
+            ]
+          }
+        ]
+      }
+
+      const cooperation = await cooperationService.createCooperation(currentUser.id, roles.TUTOR, cooperationData)
+
+      const response = await app
+        .delete(endpointUrl + testLessonResponse.body._id)
+        .set('Cookie', [`accessToken=${accessToken}`])
+
+      const updatedCooperation = await cooperationService.getCooperationById(cooperation._id, roles.TUTOR)
+
+      expect(response.statusCode).toBe(204)
+
+      updatedCooperation.sections.forEach((section) => {
+        expect(section.resources).toHaveLength(0)
+      })
     })
   })
 

--- a/src/test/integration/controllers/quiz.spec.js
+++ b/src/test/integration/controllers/quiz.spec.js
@@ -9,6 +9,9 @@ const {
 const {
   enums: { QUIZ_VIEW_ENUM, RESOURCES_TYPES_ENUM, QUIZ_TIME_LIMIT, QUIZ_ATTEMPT_LIMIT }
 } = require('~/consts/validation')
+const resourceType = require('~/consts/resourceType')
+const { roles } = require('~/consts/auth')
+const cooperationService = require('~/services/cooperation')
 
 const endpointUrl = '/quizzes/'
 const questionEndpointUrl = '/questions/'
@@ -251,6 +254,55 @@ describe('Quiz controller', () => {
       const response = await app.delete(endpointUrl + testQuizId).set('Cookie', [`accessToken=${studentAccessToken}`])
 
       expectError(403, FORBIDDEN, response)
+    })
+
+    it('should delete lesson and remove references from all cooperation sections', async () => {
+      const cooperationData = {
+        offer: '82a51e41de4debbccf0b3111',
+        initiator: currentUser.id,
+        initiatorRole: 'tutor',
+        receiver: '62a51e41de4debbccf0b3111',
+        receiverRole: 'student',
+        title: 'Web Development Course',
+        proficiencyLevel: 'Beginner',
+        price: 500,
+        status: 'active',
+        needAction: 'student',
+        sections: [
+          {
+            title: 'Start with HTML',
+            description: 'Learn the basics of HTML',
+            resources: [
+              {
+                resource: testQuizId,
+                resourceType: resourceType.QUIZ
+              }
+            ]
+          },
+          {
+            title: 'Continue with CSS',
+            description: 'Learn the basics of CSS',
+            resources: [
+              {
+                resource: testQuizId,
+                resourceType: resourceType.QUIZ
+              }
+            ]
+          }
+        ]
+      }
+
+      const cooperation = await cooperationService.createCooperation(currentUser.id, roles.TUTOR, cooperationData)
+
+      const response = await app.delete(endpointUrl + testQuizId).set('Cookie', [`accessToken=${accessToken}`])
+
+      const updatedCooperation = await cooperationService.getCooperationById(cooperation._id, roles.TUTOR)
+
+      expect(response.statusCode).toBe(204)
+
+      updatedCooperation.sections.forEach((section) => {
+        expect(section.resources).toHaveLength(0)
+      })
     })
   })
 })


### PR DESCRIPTION
- Add removeResourceFromCooperations method to cooperation to remove specific resource by id
- Call removeResourceFromCooperations inside quiz, attachement, lesson delete methods
- Add tests to ensure deleted resources references are removed from all cooperation sections

Before:

https://github.com/user-attachments/assets/77deb59f-15cd-4a20-991c-5b37b4ac395f

After:

https://github.com/user-attachments/assets/7b5ccfb7-0d57-469d-b0a9-69feb22e49c2



<details>
<summary> Fix edit attachment method to ensure only valid category, "" description are allowed</summary>
Before:

Not an id:

![image](https://github.com/user-attachments/assets/16b3a2d8-0510-4d20-9d40-fff0ee3f5adb)

Not valid refrence:

![image](https://github.com/user-attachments/assets/82879b30-5245-485c-9e75-e4dae00df834)


After:
![image](https://github.com/user-attachments/assets/91a96beb-23e6-4900-b066-96555704cee2)
![image](https://github.com/user-attachments/assets/f649da54-2398-43b7-baa6-758a582ebb1a)

Valid id:
![image](https://github.com/user-attachments/assets/3779a50c-9f31-4e06-9772-3c4a59e4ebe9)
</details>

