### PR TITLE
Fix related documents not removed on user deletion

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,13 @@
   "rules": {
     "indent": ["error", 2],
     "linebreak-style": ["error", "windows"],
-    "quotes": ["error", "single"],
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true
+      }
+    ],
     "semi": ["error", "never"],
     "eol-last": ["error", "always"],
     "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 1, "maxBOF": 0 }],

--- a/src/controllers/attachment.js
+++ b/src/controllers/attachment.js
@@ -51,7 +51,7 @@ const deleteAttachment = async (req, res) => {
   const { id } = req.params
   const { id: currentUser } = req.user
 
-  await attachmentService.deleteAttachment(id, currentUser)
+  await attachmentService.deleteAttachmentById(id, currentUser)
 
   res.status(204).end()
 }

--- a/src/services/attachment.js
+++ b/src/services/attachment.js
@@ -102,7 +102,7 @@ const attachmentService = {
   },
 
   deleteAttachementsByAuthor: async (author) => {
-    return Attachment.deleteMany({ author })
+    await Attachment.deleteMany({ author })
   }
 }
 

--- a/src/services/attachment.js
+++ b/src/services/attachment.js
@@ -87,7 +87,7 @@ const attachmentService = {
     return attachment.populate({ path: 'category', select: '_id name' })
   },
 
-  deleteAttachment: async (id, currentUser) => {
+  deleteAttachmentById: async (id, currentUser) => {
     const item = await Attachment.findById(id).exec()
 
     const attachmentAuthor = item.author.toString()
@@ -99,6 +99,10 @@ const attachmentService = {
     await cooperationService.removeResourceFromCooperations(id, resourceType.ATTACHMENT, currentUser)
 
     await Attachment.findByIdAndRemove(id)
+  },
+
+  deleteAttachementsByAuthor: async (author) => {
+    return Attachment.deleteMany({ author })
   }
 }
 

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose')
 const { CHAT_ALREADY_EXISTS } = require('~/consts/errors')
 
 const Chat = require('~/models/chat')
+const { mapToId } = require('~/utils/mapToId')
 const { createForbiddenError, createError } = require('~/utils/errorsHelper')
 const messageService = require('./message')
 
@@ -91,7 +92,7 @@ const chatService = {
       $expr: { $lte: [{ $size: '$members' }, 2] }
     }).lean()
 
-    const chatIds = chatsToDelete.map((chat) => chat._id)
+    const chatIds = mapToId(chatsToDelete)
 
     messageService.deleteAllMessagesByChatIds(chatIds)
 

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -97,7 +97,15 @@ const chatService = {
 
     await Chat.deleteMany({
       _id: { $in: chatIds }
-    }).exec()
+    })
+
+    await Chat.updateMany(
+      {
+        'members.user': currentUser,
+        $expr: { $gt: [{ $size: '$members' }, 2] }
+      },
+      { $pull: { members: { user: currentUser } } }
+    )
   }
 }
 

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -94,7 +94,7 @@ const chatService = {
 
     const chatIds = mapToId(chatsToDelete)
 
-    messageService.deleteAllMessagesByChatIds(chatIds)
+    await messageService.deleteAllMessagesByChatIds(chatIds)
 
     await Chat.deleteMany({
       _id: { $in: chatIds }

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -3,6 +3,7 @@ const { CHAT_ALREADY_EXISTS } = require('~/consts/errors')
 
 const Chat = require('~/models/chat')
 const { createForbiddenError, createError } = require('~/utils/errorsHelper')
+const messageService = require('./message')
 
 const chatService = {
   createChat: async (currentUser, data) => {
@@ -82,6 +83,21 @@ const chatService = {
     await chat.validate()
     await chat.save()
     return chat
+  },
+
+  deleteChatsbyUser: async (currentUser) => {
+    const chatsToDelete = await Chat.find({
+      'members.user': currentUser,
+      $expr: { $lte: [{ $size: '$members' }, 2] }
+    }).lean()
+
+    const chatIds = chatsToDelete.map((chat) => chat._id)
+
+    messageService.deleteAllMessagesByChatIds(chatIds)
+
+    await Chat.deleteMany({
+      _id: { $in: chatIds }
+    }).exec()
   }
 }
 

--- a/src/services/cooperation.js
+++ b/src/services/cooperation.js
@@ -3,6 +3,7 @@ const mergeArraysUniqueValues = require('~/utils/mergeArraysUniqueValues')
 const removeArraysUniqueValues = require('~/utils/removeArraysUniqueValues')
 const getCooperationByIdQueryPipeline = require('~/utils/cooperations/getCooperationByIdQueryPipeline')
 const handleResources = require('~/utils/handleResources')
+const { mapToId } = require('~/utils/mapToId')
 const { createError, createForbiddenError } = require('~/utils/errorsHelper')
 const { VALIDATION_ERROR, DOCUMENT_NOT_FOUND, ROLE_REQUIRED_FOR_ACTION } = require('~/consts/errors')
 const { roles } = require('~/consts/auth')
@@ -10,6 +11,7 @@ const {
   enums: { COOPERATION_STATUS_ENUM }
 } = require('~/consts/validation')
 const offerService = require('./offer')
+const noteService = require('./note')
 
 const cooperationService = {
   _validateCooperationUser: (cooperation, userId) => {
@@ -218,9 +220,12 @@ const cooperationService = {
     })
       .select('offer')
       .lean()
-    const offerIdsWithUserAsReceiver = cooperationsWithUser.map((cooperation) => cooperation.offer)
 
-    await offerService.removeEnrolledUser(offerIdsWithUserAsReceiver, userId)
+    const offerIdsWithUser = cooperationsWithUser.map((cooperation) => cooperation.offer)
+    await offerService.removeEnrolledUser(offerIdsWithUser, userId)
+
+    const cooperationsWithUserIds = mapToId(cooperationsWithUser)
+    await noteService.deleteNotesByCooperations(cooperationsWithUserIds)
 
     await Cooperation.deleteMany({ $or: [{ receiver: userId }, { initiator: userId }] })
   }

--- a/src/services/cooperation.js
+++ b/src/services/cooperation.js
@@ -9,6 +9,7 @@ const { roles } = require('~/consts/auth')
 const {
   enums: { COOPERATION_STATUS_ENUM }
 } = require('~/consts/validation')
+const offerService = require('./offer')
 
 const cooperationService = {
   _validateCooperationUser: (cooperation, userId) => {
@@ -209,6 +210,19 @@ const cooperationService = {
       },
       { $pull: { 'sections.$[].resources': { resourceType: resourceType, resource: resourceId } } }
     )
+  },
+
+  deleteCooperationsByUser: async (userId) => {
+    const cooperationsWithUser = await Cooperation.find({
+      $or: [{ receiver: userId }, { initiator: userId }]
+    })
+      .select('offer')
+      .lean()
+    const offerIdsWithUserAsReceiver = cooperationsWithUser.map((cooperation) => cooperation.offer)
+
+    await offerService.removeEnrolledUser(offerIdsWithUserAsReceiver, userId)
+
+    await Cooperation.deleteMany({ $or: [{ receiver: userId }, { initiator: userId }] })
   }
 }
 

--- a/src/services/course.js
+++ b/src/services/course.js
@@ -104,6 +104,10 @@ const courseService = {
     await deleteDuplicateResources(course)
 
     await Course.findByIdAndRemove(id).exec()
+  },
+
+  deleteCoursesByAuthor: async (author) => {
+    await Course.deleteMany({ author })
   }
 }
 

--- a/src/services/lesson.js
+++ b/src/services/lesson.js
@@ -62,6 +62,10 @@ const lessonService = {
 
   getLessonById: async (id) => {
     return await Lesson.findById(id).populate('attachments').lean().exec()
+  },
+
+  deleteLessonsByAuthor: async (author) => {
+    return Lesson.deleteMany({ author })
   }
 }
 

--- a/src/services/lesson.js
+++ b/src/services/lesson.js
@@ -65,7 +65,7 @@ const lessonService = {
   },
 
   deleteLessonsByAuthor: async (author) => {
-    return Lesson.deleteMany({ author })
+    await Lesson.deleteMany({ author })
   }
 }
 

--- a/src/services/message.js
+++ b/src/services/message.js
@@ -95,6 +95,14 @@ const messageService = {
     await Message.deleteMany({ chat })
   },
 
+  deleteAllMessagesByChatIds: async (chatIds) => {
+    await Message.deleteMany({ chat: { $in: chatIds } })
+  },
+
+  deleteAllMessagesByUser: async (userId) => {
+    await Message.deleteMany({ author: userId })
+  },
+
   clearHistory: async (match) => {
     const { user, chat } = match
 

--- a/src/services/note.js
+++ b/src/services/note.js
@@ -68,6 +68,10 @@ const noteService = {
 
   deleteNotesByAuthor: async (author) => {
     await Note.deleteMany({ author })
+  },
+
+  deleteNotesByCooperations: async (cooperations) => {
+    await Note.deleteMany({ cooperation: { $in: cooperations } })
   }
 }
 

--- a/src/services/note.js
+++ b/src/services/note.js
@@ -64,6 +64,10 @@ const noteService = {
     if (!note || note.author.toString() !== userId) throw createForbiddenError()
 
     await Note.findByIdAndRemove(noteId).exec()
+  },
+
+  deleteNotesByAuthor: async (author) => {
+    await Note.deleteMany({ author })
   }
 }
 

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -113,6 +113,14 @@ const offerService = {
 
   deleteOffer: async (id) => {
     await Offer.findByIdAndRemove(id).exec()
+  },
+
+  deleteOffersByAuthor: async (author) => {
+    await Offer.deleteMany({ author })
+  },
+
+  removeEnrolledUser: async (offerIds, userId) => {
+    await Offer.updateMany({ _id: { $in: offerIds } }, { $pull: { enrolledUsers: userId } })
   }
 }
 

--- a/src/services/question.js
+++ b/src/services/question.js
@@ -65,7 +65,7 @@ const questionService = {
   },
 
   deleteQuestionsByAuthor: async (author) => {
-    return Question.deleteMany({ author })
+    await Question.deleteMany({ author })
   }
 }
 

--- a/src/services/question.js
+++ b/src/services/question.js
@@ -62,6 +62,10 @@ const questionService = {
 
     await question.save()
     return question.populate({ path: 'category', select: '_id name' })
+  },
+
+  deleteQuestionsByAuthor: async (author) => {
+    return Question.deleteMany({ author })
   }
 }
 

--- a/src/services/quiz.js
+++ b/src/services/quiz.js
@@ -73,7 +73,7 @@ const quizService = {
   },
 
   deleteQuizzesByAuthor: async (author) => {
-    return Quiz.deleteMany({ author })
+    await Quiz.deleteMany({ author })
   }
 }
 

--- a/src/services/quiz.js
+++ b/src/services/quiz.js
@@ -70,6 +70,10 @@ const quizService = {
     await cooperationService.removeResourceFromCooperations(id, resourceType.QUIZ, currentUserId)
 
     await Quiz.findByIdAndRemove(id).exec()
+  },
+
+  deleteQuizzesByAuthor: async (author) => {
+    return Quiz.deleteMany({ author })
   }
 }
 

--- a/src/services/resourcesCategory.js
+++ b/src/services/resourcesCategory.js
@@ -56,6 +56,10 @@ const resourcesCategoryService = {
     }
 
     await ResourcesCategory.findByIdAndRemove(id).exec()
+  },
+
+  deleteResourceCategoriesByAuthor: async (author) => {
+    await ResourcesCategory.deleteMany({ author })
   }
 }
 

--- a/src/services/review.js
+++ b/src/services/review.js
@@ -5,6 +5,9 @@ const filterAllowedFields = require('~/utils/filterAllowedFields')
 const { allowedReviewFieldsForUpdate } = require('~/validation/services/review')
 const cooperationService = require('./cooperation')
 const { CANNOT_TARGET_SELF } = require('~/consts/errors')
+const {
+  enums: { MAIN_ROLE_ENUM }
+} = require('~/consts/validation')
 const getReviewsAggregateOptions = require('~/utils/reviews/getReviewsAggregateOptions')
 
 const reviewService = {
@@ -108,6 +111,10 @@ const reviewService = {
     await Review.deleteMany({
       $or: [{ author: userId }, { targetUserId: userId }]
     })
+
+    for (const role of MAIN_ROLE_ENUM) {
+      await calculateReviewStats(userId, role)
+    }
 
     for (const review of reviewsCreatedByUser) {
       await calculateReviewStats(review.targetUserId, review.targetUserRole)

--- a/src/services/review.js
+++ b/src/services/review.js
@@ -100,6 +100,12 @@ const reviewService = {
 
     await Review.findByIdAndRemove(id).exec()
     await calculateReviewStats(targetUserId, targetUserRole)
+  },
+
+  deleteReviewsByAuthorOrTarget: async (userId) => {
+    await Review.deleteMany({
+      $or: [{ author: userId }, { targetUserId: userId }]
+    })
   }
 }
 

--- a/src/services/review.js
+++ b/src/services/review.js
@@ -112,13 +112,11 @@ const reviewService = {
       $or: [{ author: userId }, { targetUserId: userId }]
     })
 
-    for (const role of MAIN_ROLE_ENUM) {
-      await calculateReviewStats(userId, role)
-    }
+    await Promise.all(MAIN_ROLE_ENUM.map((role) => calculateReviewStats(userId, role)))
 
-    for (const review of reviewsCreatedByUser) {
-      await calculateReviewStats(review.targetUserId, review.targetUserRole)
-    }
+    await Promise.all(
+      reviewsCreatedByUser.map((review) => calculateReviewStats(review.targetUserId, review.targetUserRole))
+    )
   }
 }
 

--- a/src/services/review.js
+++ b/src/services/review.js
@@ -103,9 +103,15 @@ const reviewService = {
   },
 
   deleteReviewsByAuthorOrTarget: async (userId) => {
+    const reviewsCreatedByUser = await Review.find({ author: userId })
+
     await Review.deleteMany({
       $or: [{ author: userId }, { targetUserId: userId }]
     })
+
+    for (const review of reviewsCreatedByUser) {
+      await calculateReviewStats(review.targetUserId, review.targetUserRole)
+    }
   }
 }
 

--- a/src/services/token.js
+++ b/src/services/token.js
@@ -113,6 +113,10 @@ const tokenService = {
 
   removeConfirmToken: async (confirmToken) => {
     await Token.deleteOne({ confirmToken })
+  },
+
+  deleteTokensByUser: async (user) => {
+    await Token.deleteMany({ user })
   }
 }
 

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -32,6 +32,7 @@ const questionService = require('./question')
 const resourcesCategoryService = require('./resourcesCategory')
 const noteService = require('./note')
 const courseService = require('./course')
+const tokenService = require('./token')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -296,6 +297,7 @@ const userService = {
     resourcesCategoryService.deleteResourceCategoriesByAuthor(id)
     noteService.deleteNotesByAuthor(id)
     courseService.deleteCoursesByAuthor(id)
+    tokenService.deleteTokensByUser(id)
 
     await User.findByIdAndRemove(id)
   },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -33,6 +33,7 @@ const resourcesCategoryService = require('./resourcesCategory')
 const noteService = require('./note')
 const courseService = require('./course')
 const tokenService = require('./token')
+const reviewService = require('./review')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -297,6 +298,9 @@ const userService = {
     resourcesCategoryService.deleteResourceCategoriesByAuthor(id)
     noteService.deleteNotesByAuthor(id)
     courseService.deleteCoursesByAuthor(id)
+
+    reviewService.deleteReviewsByAuthorOrTarget(id)
+
     tokenService.deleteTokensByUser(id)
 
     await User.findByIdAndRemove(id)

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -24,6 +24,8 @@ const offerService = require('./offer')
 const cooperationService = require('./cooperation')
 const offerAggregateOptions = require('~/utils/offers/offerAggregateOptions')
 
+const notificationService = require('./notification')
+
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
     const count = await User.countDocuments(match)
@@ -279,7 +281,9 @@ const userService = {
   },
 
   deleteUser: async (id) => {
-    await User.findByIdAndRemove(id).exec()
+    await notificationService.clearNotifications(id)
+
+    await User.findByIdAndRemove(id)
   },
 
   toggleOfferBookmark: async (offerId, userId) => {

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -34,6 +34,8 @@ const courseService = require('./course')
 const tokenService = require('./token')
 const reviewService = require('./review')
 const cooperationService = require('./cooperation')
+const chatService = require('./chat')
+const messageService = require('./message')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -303,6 +305,9 @@ const userService = {
 
     cooperationService.deleteCooperationsByUser(id)
     offerService.deleteOffersByAuthor(id)
+
+    chatService.deleteChatsbyUser(id)
+    messageService.deleteAllMessagesByUser(id)
 
     tokenService.deleteTokensByUser(id)
 

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -21,7 +21,6 @@ const { allowedTutorFieldsForUpdate } = require('~/validation/services/user')
 const { allowedStudentFieldsForUpdate } = require('~/validation/services/user')
 const { shouldDeletePreviousPhoto } = require('~/utils/users/photoCheck')
 const offerService = require('./offer')
-const cooperationService = require('./cooperation')
 const offerAggregateOptions = require('~/utils/offers/offerAggregateOptions')
 
 const notificationService = require('./notification')
@@ -34,6 +33,7 @@ const noteService = require('./note')
 const courseService = require('./course')
 const tokenService = require('./token')
 const reviewService = require('./review')
+const cooperationService = require('./cooperation')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -300,6 +300,9 @@ const userService = {
     courseService.deleteCoursesByAuthor(id)
 
     reviewService.deleteReviewsByAuthorOrTarget(id)
+
+    cooperationService.deleteCooperationsByUser(id)
+    offerService.deleteOffersByAuthor(id)
 
     tokenService.deleteTokensByUser(id)
 

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -27,6 +27,7 @@ const offerAggregateOptions = require('~/utils/offers/offerAggregateOptions')
 const notificationService = require('./notification')
 const attachmentService = require('./attachment')
 const lessonService = require('./lesson')
+const quizService = require('./quiz')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -286,6 +287,7 @@ const userService = {
     await notificationService.clearNotifications(id)
     await attachmentService.deleteAttachementsByAuthor(id)
     await lessonService.deleteLessonsByAuthor(id)
+    await quizService.deleteQuizzesByAuthor(id)
 
     await User.findByIdAndRemove(id)
   },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -292,24 +292,22 @@ const userService = {
   },
 
   deleteUser: async (id) => {
-    notificationService.clearNotifications(id)
-    attachmentService.deleteAttachementsByAuthor(id)
-    lessonService.deleteLessonsByAuthor(id)
-    quizService.deleteQuizzesByAuthor(id)
-    questionService.deleteQuestionsByAuthor(id)
-    resourcesCategoryService.deleteResourceCategoriesByAuthor(id)
-    noteService.deleteNotesByAuthor(id)
-    courseService.deleteCoursesByAuthor(id)
-
-    reviewService.deleteReviewsByAuthorOrTarget(id)
-
-    cooperationService.deleteCooperationsByUser(id)
-    offerService.deleteOffersByAuthor(id)
-
-    chatService.deleteChatsbyUser(id)
-    messageService.deleteAllMessagesByUser(id)
-
-    tokenService.deleteTokensByUser(id)
+    await Promise.all([
+      notificationService.clearNotifications(id),
+      attachmentService.deleteAttachementsByAuthor(id),
+      lessonService.deleteLessonsByAuthor(id),
+      quizService.deleteQuizzesByAuthor(id),
+      questionService.deleteQuestionsByAuthor(id),
+      resourcesCategoryService.deleteResourceCategoriesByAuthor(id),
+      noteService.deleteNotesByAuthor(id),
+      courseService.deleteCoursesByAuthor(id),
+      reviewService.deleteReviewsByAuthorOrTarget(id),
+      cooperationService.deleteCooperationsByUser(id),
+      offerService.deleteOffersByAuthor(id),
+      chatService.deleteChatsbyUser(id),
+      messageService.deleteAllMessagesByUser(id),
+      tokenService.deleteTokensByUser(id)
+    ])
 
     await User.findByIdAndRemove(id)
   },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -25,6 +25,7 @@ const cooperationService = require('./cooperation')
 const offerAggregateOptions = require('~/utils/offers/offerAggregateOptions')
 
 const notificationService = require('./notification')
+const attachmentService = require('./attachment')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -282,6 +283,7 @@ const userService = {
 
   deleteUser: async (id) => {
     await notificationService.clearNotifications(id)
+    await attachmentService.deleteAttachementsByAuthor(id)
 
     await User.findByIdAndRemove(id)
   },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -31,6 +31,7 @@ const quizService = require('./quiz')
 const questionService = require('./question')
 const resourcesCategoryService = require('./resourcesCategory')
 const noteService = require('./note')
+const courseService = require('./course')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -294,6 +295,7 @@ const userService = {
     questionService.deleteQuestionsByAuthor(id)
     resourcesCategoryService.deleteResourceCategoriesByAuthor(id)
     noteService.deleteNotesByAuthor(id)
+    courseService.deleteCoursesByAuthor(id)
 
     await User.findByIdAndRemove(id)
   },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -29,6 +29,7 @@ const attachmentService = require('./attachment')
 const lessonService = require('./lesson')
 const quizService = require('./quiz')
 const questionService = require('./question')
+const resourcesCategoryService = require('./resourcesCategory')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -285,11 +286,12 @@ const userService = {
   },
 
   deleteUser: async (id) => {
-    await notificationService.clearNotifications(id)
-    await attachmentService.deleteAttachementsByAuthor(id)
-    await lessonService.deleteLessonsByAuthor(id)
-    await quizService.deleteQuizzesByAuthor(id)
-    await questionService.deleteQuestionsByAuthor(id)
+    notificationService.clearNotifications(id)
+    attachmentService.deleteAttachementsByAuthor(id)
+    lessonService.deleteLessonsByAuthor(id)
+    quizService.deleteQuizzesByAuthor(id)
+    questionService.deleteQuestionsByAuthor(id)
+    resourcesCategoryService.deleteResourceCategoriesByAuthor(id)
 
     await User.findByIdAndRemove(id)
   },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -28,6 +28,7 @@ const notificationService = require('./notification')
 const attachmentService = require('./attachment')
 const lessonService = require('./lesson')
 const quizService = require('./quiz')
+const questionService = require('./question')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -288,6 +289,7 @@ const userService = {
     await attachmentService.deleteAttachementsByAuthor(id)
     await lessonService.deleteLessonsByAuthor(id)
     await quizService.deleteQuizzesByAuthor(id)
+    await questionService.deleteQuestionsByAuthor(id)
 
     await User.findByIdAndRemove(id)
   },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -26,6 +26,7 @@ const offerAggregateOptions = require('~/utils/offers/offerAggregateOptions')
 
 const notificationService = require('./notification')
 const attachmentService = require('./attachment')
+const lessonService = require('./lesson')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -284,6 +285,7 @@ const userService = {
   deleteUser: async (id) => {
     await notificationService.clearNotifications(id)
     await attachmentService.deleteAttachementsByAuthor(id)
+    await lessonService.deleteLessonsByAuthor(id)
 
     await User.findByIdAndRemove(id)
   },

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -30,6 +30,7 @@ const lessonService = require('./lesson')
 const quizService = require('./quiz')
 const questionService = require('./question')
 const resourcesCategoryService = require('./resourcesCategory')
+const noteService = require('./note')
 
 const userService = {
   getUsers: async ({ match, sort, skip, limit }) => {
@@ -292,6 +293,7 @@ const userService = {
     quizService.deleteQuizzesByAuthor(id)
     questionService.deleteQuestionsByAuthor(id)
     resourcesCategoryService.deleteResourceCategoriesByAuthor(id)
+    noteService.deleteNotesByAuthor(id)
 
     await User.findByIdAndRemove(id)
   },

--- a/src/test/integration/controllers/user.spec.js
+++ b/src/test/integration/controllers/user.spec.js
@@ -22,6 +22,7 @@ const notificationService = require('~/services/notification')
 const lessonService = require('~/services/lesson')
 const questionService = require('~/services/question')
 const resourcesCategoryService = require('~/services/resourcesCategory')
+const reviewService = require('~/services/review')
 
 const userService = require('~/services/user')
 const { deleteUser } = require('~/controllers/user')
@@ -878,6 +879,13 @@ describe('User controller', () => {
   describe('User deletion cascade effects', () => {
     let accessToken, currentUser, req, res
 
+    const reviewData = {
+      comment: 'Good mentor and learning program',
+      rating: 5,
+      targetUserRole: 'student',
+      offer: '6502ec2060ec37be943353e2'
+    }
+
     beforeEach(async () => {
       accessToken = await testUserAuthentication(app, adminUser)
       currentUser = TokenService.validateAccessToken(accessToken)
@@ -971,6 +979,32 @@ describe('User controller', () => {
       })
 
       expect(updatedResourcesCategories.count).toBe(0)
+    })
+
+    it('should remove all reviews where deleted user is target user', async () => {
+      const authorId = '65afa47f3d67b51996a67b92'
+
+      await reviewService.addReview(authorId, { ...reviewData, targetUserId: currentUser.id })
+
+      await deleteUser(req, res)
+
+      expect(res.end).toHaveBeenCalled()
+
+      const reviewsWithUser = await reviewService.getReviews({ targetUserId: currentUser.id })
+      expect(reviewsWithUser.count).toBe(0)
+    })
+
+    it('should remove all reviews where deleted user is the author', async () => {
+      const authorId = currentUser.id
+
+      await reviewService.addReview(authorId, { ...reviewData, targetUserId: '65afa47f3d67b51996a67b92' })
+
+      await deleteUser(req, res)
+
+      expect(res.end).toHaveBeenCalled()
+
+      const reviewsWithUser = await reviewService.getReviews({ author: currentUser.id })
+      expect(reviewsWithUser.count).toBe(0)
     })
   })
 })

--- a/src/test/integration/controllers/user.spec.js
+++ b/src/test/integration/controllers/user.spec.js
@@ -1049,7 +1049,6 @@ describe('User controller', () => {
 
       const updatedOffer = await offerService.getOffers([{ $match: { _id: offer._id } }])
 
-      console.log(updatedOffer)
       expect(updatedOffer.enrolledUsers).not.toContain(currentUser.id)
     })
   })

--- a/src/test/integration/controllers/user.spec.js
+++ b/src/test/integration/controllers/user.spec.js
@@ -20,6 +20,8 @@ const userService = require('~/services/user')
 const uploadService = require('~/services/upload')
 const { default: mongoose } = require('mongoose')
 
+const notificationService = require('~/services/notification')
+
 const endpointUrl = '/users/'
 const logoutEndpoint = '/auth/logout'
 
@@ -482,6 +484,7 @@ describe('User controller', () => {
       })
     })
   })
+
   describe('Restricted endpoints only by admin access rights', () => {
     let accessToken, currentUser
 
@@ -865,6 +868,37 @@ describe('User controller', () => {
       expect(updatedUser.photo).toBe('http://example.com/newPhoto.jpg')
 
       mockUploadFile.mockRestore()
+    })
+  })
+
+  describe('User deletion cascade effects', () => {
+    let accessToken, currentUser
+
+    beforeEach(async () => {
+      accessToken = await testUserAuthentication(app, adminUser)
+      currentUser = TokenService.validateAccessToken(accessToken)
+    })
+
+    afterEach(async () => {
+      await app.post(logoutEndpoint)
+    })
+
+    it('should remove all notifications related to the user', async () => {
+      const notificationData = {
+        user: currentUser.id,
+        userRole: 'tutor',
+        type: 'active',
+        reference: '6736199d6b214652201af5d1',
+        referenceModel: 'Cooperation'
+      }
+
+      await notificationService.createNotification(notificationData)
+
+      await userService.deleteUser(currentUser.id)
+
+      const notificationsWithUser = await notificationService.getNotifications({ user: currentUser.id })
+      console.log(notificationsWithUser)
+      expect(notificationsWithUser.count).toBe(0)
     })
   })
 })

--- a/src/test/integration/controllers/user.spec.js
+++ b/src/test/integration/controllers/user.spec.js
@@ -21,6 +21,7 @@ const uploadService = require('~/services/upload')
 const { default: mongoose } = require('mongoose')
 
 const notificationService = require('~/services/notification')
+const lessonService = require('~/services/lesson')
 
 const endpointUrl = '/users/'
 const logoutEndpoint = '/auth/logout'
@@ -897,8 +898,24 @@ describe('User controller', () => {
       await userService.deleteUser(currentUser.id)
 
       const notificationsWithUser = await notificationService.getNotifications({ user: currentUser.id })
-      console.log(notificationsWithUser)
       expect(notificationsWithUser.count).toBe(0)
+    })
+
+    it('should remove all lessons related to the user', async () => {
+      const lessonData = {
+        title: 'Basics of css',
+        description: 'Learn the basics of css',
+        category: '6502ec2060ec37be943353e2',
+        content: '<h1>Basics of css</h1> <p>Css is a language used to style web pages</p>'
+      }
+
+      await lessonService.createLesson(currentUser.id, lessonData)
+
+      await userService.deleteUser(currentUser.id)
+
+      const attachmentsWithUser = await lessonService.getLessons({ author: currentUser.id })
+
+      expect(attachmentsWithUser.count).toBe(0)
     })
   })
 })

--- a/src/test/integration/controllers/user.spec.js
+++ b/src/test/integration/controllers/user.spec.js
@@ -21,6 +21,7 @@ const uploadService = require('~/services/upload')
 const notificationService = require('~/services/notification')
 const lessonService = require('~/services/lesson')
 const questionService = require('~/services/question')
+const resourcesCategoryService = require('~/services/resourcesCategory')
 
 const userService = require('~/services/user')
 const { deleteUser } = require('~/controllers/user')
@@ -874,7 +875,7 @@ describe('User controller', () => {
     })
   })
 
-  describe.only('User deletion cascade effects', () => {
+  describe('User deletion cascade effects', () => {
     let accessToken, currentUser, req, res
 
     beforeEach(async () => {
@@ -952,6 +953,24 @@ describe('User controller', () => {
       const questionsWithUser = await questionService.getQuestions({ author: currentUser.id })
 
       expect(questionsWithUser.count).toBe(0)
+    })
+
+    it('should remove all resources categories related to the user', async () => {
+      const categoryData = {
+        name: 'Basics of web development'
+      }
+
+      await resourcesCategoryService.createResourcesCategory(currentUser.id, categoryData)
+
+      await deleteUser(req, res)
+
+      expect(res.end).toHaveBeenCalled()
+
+      const updatedResourcesCategories = await resourcesCategoryService.getResourcesCategories({
+        author: currentUser.id
+      })
+
+      expect(updatedResourcesCategories.count).toBe(0)
     })
   })
 })

--- a/src/test/integration/controllers/user.spec.js
+++ b/src/test/integration/controllers/user.spec.js
@@ -23,6 +23,8 @@ const lessonService = require('~/services/lesson')
 const questionService = require('~/services/question')
 const resourcesCategoryService = require('~/services/resourcesCategory')
 const reviewService = require('~/services/review')
+const offerService = require('~/services/offer')
+const cooperationService = require('~/services/cooperation')
 
 const userService = require('~/services/user')
 const { deleteUser } = require('~/controllers/user')
@@ -1005,6 +1007,50 @@ describe('User controller', () => {
 
       const reviewsWithUser = await reviewService.getReviews({ author: currentUser.id })
       expect(reviewsWithUser.count).toBe(0)
+    })
+
+    it('should remove user from enrolled user in offers if user identified as receiver in cooperation', async () => {
+      const offerData = {
+        price: 600,
+        proficiencyLevel: ['Beginner'],
+        title: 'Learn how to play guitar',
+        description: 'The most beginner-friendly guitar lessons',
+        languages: ['English'],
+        subject: '6502ec2060ec37be943353e2',
+        category: '6502ec2060ec37be943353e2',
+        enrolledUsers: [currentUser.id]
+      }
+
+      const offerAuthorId = '65afa47f3d67b51996a67b92'
+      const offerAuthorRole = 'tutor'
+      const offerEnrolledUserRole = 'student'
+
+      const offer = await offerService.createOffer(offerAuthorId, offerAuthorRole, offerData)
+
+      const cooperationData = {
+        user: currentUser.id,
+        offer: offer._id,
+        status: 'active',
+        receiverRole: offerAuthorRole,
+        receiver: offerAuthorId,
+        title: 'Learn how to play guitar',
+        proficiencyLevel: 'Beginner',
+        price: 600,
+        needAction: {
+          role: 'tutor'
+        }
+      }
+
+      await cooperationService.createCooperation(currentUser.id, offerEnrolledUserRole, cooperationData)
+
+      await deleteUser(req, res)
+
+      expect(res.end).toHaveBeenCalled()
+
+      const updatedOffer = await offerService.getOffers([{ $match: { _id: offer._id } }])
+
+      console.log(updatedOffer)
+      expect(updatedOffer.enrolledUsers).not.toContain(currentUser.id)
     })
   })
 })

--- a/src/test/integration/controllers/user.spec.js
+++ b/src/test/integration/controllers/user.spec.js
@@ -12,16 +12,18 @@ const {
 const {
   enums: { STATUS_ENUM }
 } = require('~/consts/validation')
+const { default: mongoose } = require('mongoose')
 
 const testUserAuthentication = require('~/utils/testUserAuth')
 const createAggregateOptions = require('~/utils/users/createAggregateOptions')
 const TokenService = require('~/services/token')
-const userService = require('~/services/user')
 const uploadService = require('~/services/upload')
-const { default: mongoose } = require('mongoose')
-
 const notificationService = require('~/services/notification')
 const lessonService = require('~/services/lesson')
+const questionService = require('~/services/question')
+
+const userService = require('~/services/user')
+const { deleteUser } = require('~/controllers/user')
 
 const endpointUrl = '/users/'
 const logoutEndpoint = '/auth/logout'
@@ -872,12 +874,18 @@ describe('User controller', () => {
     })
   })
 
-  describe('User deletion cascade effects', () => {
-    let accessToken, currentUser
+  describe.only('User deletion cascade effects', () => {
+    let accessToken, currentUser, req, res
 
     beforeEach(async () => {
       accessToken = await testUserAuthentication(app, adminUser)
       currentUser = TokenService.validateAccessToken(accessToken)
+
+      req = { params: { id: currentUser.id } }
+      res = {
+        status: jest.fn().mockReturnThis(),
+        end: jest.fn()
+      }
     })
 
     afterEach(async () => {
@@ -895,7 +903,9 @@ describe('User controller', () => {
 
       await notificationService.createNotification(notificationData)
 
-      await userService.deleteUser(currentUser.id)
+      await deleteUser(req, res)
+
+      expect(res.end).toHaveBeenCalled()
 
       const notificationsWithUser = await notificationService.getNotifications({ user: currentUser.id })
       expect(notificationsWithUser.count).toBe(0)
@@ -911,11 +921,37 @@ describe('User controller', () => {
 
       await lessonService.createLesson(currentUser.id, lessonData)
 
-      await userService.deleteUser(currentUser.id)
+      await deleteUser(req, res)
+
+      expect(res.end).toHaveBeenCalled()
 
       const attachmentsWithUser = await lessonService.getLessons({ author: currentUser.id })
 
       expect(attachmentsWithUser.count).toBe(0)
+    })
+
+    it('should remove all questions related to the user', async () => {
+      const questionData = {
+        title: 'What is the capital of France?',
+        text: 'What is the capital of France?',
+        answers: [
+          { text: 'Paris', isCorrect: true },
+          { text: 'London', isCorrect: false },
+          { text: 'Berlin', isCorrect: false },
+          { text: 'Madrid', isCorrect: false }
+        ],
+        type: 'oneAnswer',
+        category: '6502ec2060ec37be943353e2'
+      }
+      await questionService.createQuestion(currentUser.id, questionData)
+
+      await deleteUser(req, res)
+
+      expect(res.end).toHaveBeenCalled()
+
+      const questionsWithUser = await questionService.getQuestions({ author: currentUser.id })
+
+      expect(questionsWithUser.count).toBe(0)
     })
   })
 })


### PR DESCRIPTION
Previously, the absence of a cascade delete strategy in MongoDB caused related documents to remain even after the associated user was deleted:
<details>
<summary>preview</summary>

```
Summary of all failing tests
FAIL src/test/integration/models/notification.spec.js
  ● Notification model › should have valid user references

    expect(received).toBeInstanceOf(expected)

    Expected constructor: model

    Received value has no prototype
    Received value: null

      50 |
      51 |     for (const notification of notifications) {
    > 52 |       expect(notification.user).toBeInstanceOf(User)
         |                                 ^
      53 |     }
      54 |   })
      55 |

      at Object.toBeInstanceOf (src/test/integration/models/notification.spec.js:52:33)
          at runMicrotasks (<anonymous>)

FAIL src/test/integration/models/resourcesCategory.spec.js (6.813 s)
  ● ResourcesCategory model › should have valid User references in author field

    expect(received).not.toBeNull()

    Received: null

      72 |
      73 |       const user = await User.findById(resources.author)
    > 74 |       expect(user).not.toBeNull()
         |                        ^
      75 |       expect(user).toBeInstanceOf(User)
      76 |     }
      77 |   })

      at Object.toBeNull (src/test/integration/models/resourcesCategory.spec.js:74:24)
          at runMicrotasks (<anonymous>)


Test Suites: 2 failed, 63 passed, 65 total
Tests:       2 failed, 536 passed, 538 total

```

</details>

- Add removal of documents related to the user
- Remove user references from offers and chats with more than two members, instead of completely deleting them

<details>
<summary>list of models that contain a user reference</summary>

![image](https://github.com/user-attachments/assets/2d2de950-8ff7-4dfe-9749-368baa415211)

</details>