### PR TITLE
Added canBeNull field in updateUserValidationSchema

### DIFF
--- a/src/utils/validation/schemaValidators.js
+++ b/src/utils/validation/schemaValidators.js
@@ -10,6 +10,10 @@ const validatePrimitiveSchemaField = (schemaFieldKey, schemaFieldValue, reqSourc
 }
 
 const validateSchemaField = (schemaFieldKey, schemaFieldValue, reqSourceField) => {
+  if (reqSourceField === null && schemaFieldValue.canBeNull) {
+    return
+  }
+
   if (
     typeof reqSourceField === 'object' &&
     isExpectedType('object', schemaFieldValue.type) &&

--- a/src/validation/schemas/users/updateUserValidationSchema.js
+++ b/src/validation/schemas/users/updateUserValidationSchema.js
@@ -71,6 +71,7 @@ const updateUserValidationSchema = {
   },
   professionalSummary: {
     type: 'string',
+    canBeNull: false,
     required: false,
     length: {
       min: MIN_PROFFESSIONAL_SUMMARY_LENGTH,

--- a/src/validation/schemas/users/updateUserValidationSchema.js
+++ b/src/validation/schemas/users/updateUserValidationSchema.js
@@ -79,6 +79,7 @@ const updateUserValidationSchema = {
     }
   },
   nativeLanguage: {
+    canBeNull: true,
     enum: SPOKEN_LANG_ENUM,
     required: false
   },

--- a/src/validation/schemas/users/updateUserValidationSchema.js
+++ b/src/validation/schemas/users/updateUserValidationSchema.js
@@ -71,7 +71,7 @@ const updateUserValidationSchema = {
   },
   professionalSummary: {
     type: 'string',
-    canBeNull: false,
+    canBeNull: true,
     required: false,
     length: {
       min: MIN_PROFFESSIONAL_SUMMARY_LENGTH,


### PR DESCRIPTION
This PR is related to [Frontend PR #3160](https://github.com/ita-social-projects/SpaceToStudy-Client/pull/3160).

When clearing `professionalSummary` or `nativeLanguage` on the frontend, the field value is set to null instead of an empty string (""), and I updated the updateUserValidationSchema middleware module so that the server could correctly receive and process this request.
![image](https://github.com/user-attachments/assets/9a5d5a23-b1d3-442d-a8de-dcc7a31fd1bb)
![image](https://github.com/user-attachments/assets/c33584d3-8054-40d7-b01d-bd00997e95fa)
