### PR TITLE
Created PATCH endpoint for finished quizzes

### DIFF
--- a/docs/finishedQuiz/finishedQuiz.yaml
+++ b/docs/finishedQuiz/finishedQuiz.yaml
@@ -168,7 +168,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - in: id
+        - in: path
           name: id
           required: true
           description: ID of the finished quiz that needs to be fetched
@@ -225,11 +225,12 @@ paths:
       produces:
         - application/json
       parameters:
-        - in: params
+        - in: path
           name: id
           required: true
           description: ID of the finished quiz that needs to be updated
-          type: string
+          schema:
+            type: string
       requestBody:
         description: Data to update a finished quiz
         content:

--- a/docs/finishedQuiz/finishedQuiz.yaml
+++ b/docs/finishedQuiz/finishedQuiz.yaml
@@ -215,3 +215,59 @@ paths:
                 status: 403
                 code: FORBIDDEN
                 message: You do not have permission to perform this action.
+    patch:
+      security:
+        - cookieAuth: []
+      tags:
+        - Finished quizzes
+      summary: Update finished quiz by id.
+      description: Updates finished quiz by id.
+      produces:
+        - application/json
+      parameters:
+        - in: params
+          name: id
+          required: true
+          description: ID of the finished quiz that needs to be updated
+          type: string
+      requestBody:
+        description: Data to update a finished quiz
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/finishedQuizBody'
+            example:
+              grade: 75
+      responses:
+        204:
+          description: No content
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/Error'
+              example:
+                status: 401
+                code: UNAUTHORIZED
+                message: The requested URL requires user authorization.
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/Error'
+              example:
+                status: 403
+                code: FORBIDDEN
+                message: You do not have permission to perform this action.
+        404:
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/Error'
+              example:
+                status: 404
+                code: NOT_FOUND
+                message: Quiz with the specified id was not found.

--- a/docs/quiz/quiz.yaml
+++ b/docs/quiz/quiz.yaml
@@ -52,14 +52,30 @@ paths:
                     author: '6477007a6fa4d05e1a800ce5'
                     category: '63bed9ef260f18d04ab15da'
                     settings:
-                      { view: Scroll, shuffle: true, pointValues: false, scoredResponses: false, correctAnswers: true, timeLimit: No limit, attemptLimit: No limit }
+                      {
+                        view: Scroll,
+                        shuffle: true,
+                        pointValues: false,
+                        scoredResponses: false,
+                        correctAnswers: true,
+                        timeLimit: No limit,
+                        attemptLimit: No limit
+                      }
                   - _id: 64ca5932b57f2442403394a9
                     title: Chemistry
                     items: [6477007a6fa4d05e1a800ce4, 6477007a6fa4d05e1a800ce6]
                     author: '6477007a6fa4d05e1a800ce5'
                     category: '63bed9ef260f18d04ab15da'
                     settings:
-                      { view: Scroll, shuffle: true, pointValues: false, scoredResponses: false, correctAnswers: true, timeLimit: No limit, attemptLimit: No limit }
+                      {
+                        view: Scroll,
+                        shuffle: true,
+                        pointValues: false,
+                        scoredResponses: false,
+                        correctAnswers: true,
+                        timeLimit: No limit,
+                        attemptLimit: No limit
+                      }
                 count: 2
         401:
           description: Unauthorized
@@ -102,7 +118,15 @@ paths:
               items: [6477007a6fa4d05e1a800ce4, 6477007a6fa4d05e1a800ce6]
               category: 6477007a6fa4d05e1a800ce5
               settings:
-                { view: Scroll, shuffle: true, pointValues: false, scoredResponses: false, correctAnswers: true, timeLimit: No limit, attemptLimit: No limit }
+                {
+                  view: Scroll,
+                  shuffle: true,
+                  pointValues: false,
+                  scoredResponses: false,
+                  correctAnswers: true,
+                  timeLimit: No limit,
+                  attemptLimit: No limit
+                }
       responses:
         201:
           description: Created
@@ -117,7 +141,15 @@ paths:
                 category: 6477007a6fa4d05e1a800ce5
                 _id: 63ec1cd51e9d781cdb6f4b14
                 settings:
-                  { view: Scroll, shuffle: true, pointValues: false, scoredResponses: false, correctAnswers: true, timeLimit: No limit, attemptLimit: No limit }
+                  {
+                    view: Scroll,
+                    shuffle: true,
+                    pointValues: false,
+                    scoredResponses: false,
+                    correctAnswers: true,
+                    timeLimit: No limit,
+                    attemptLimit: No limit
+                  }
                 createdAt: 2023-02-14T23:44:21.334Z
                 updatedAt: 2023-02-14T23:44:21.334Z
         401:
@@ -151,7 +183,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - in: id
+        - in: path
           name: id
           required: true
           description: ID of the quiz that needs to be fetched
@@ -172,7 +204,15 @@ paths:
                     author: 6477007a6fa4d05e1a800ce5,
                     category: 63bed9ef260f18d04ab15da
                     settings:
-                      { view: Scroll, shuffle: true, pointValues: false, scoredResponses: false, correctAnswers: true, timeLimit: No limit, attemptLimit: No limit }
+                      {
+                        view: Scroll,
+                        shuffle: true,
+                        pointValues: false,
+                        scoredResponses: false,
+                        correctAnswers: true,
+                        timeLimit: No limit,
+                        attemptLimit: No limit
+                      }
         401:
           description: Unauthorized
           content:
@@ -203,7 +243,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - in: params
+        - in: path
           name: id
           required: true
           description: ID of the quiz that needs to be updated

--- a/src/consts/errors.js
+++ b/src/consts/errors.js
@@ -15,6 +15,10 @@ const errors = {
     code: 'BODY_IS_NOT_DEFINED',
     message: 'request body should not be null or undefined.'
   },
+  QUIZ_TIME_LIMIT_EXCEEDED: {
+    code: 'QUIZ_TIME_LIMIT_EXCEEDED',
+    message: 'The time limit for the quiz has been exceeded.'
+  },
   FIELD_CAN_BE_ONE_OF: (field, enums) => ({
     code: 'FIELD_IS_NOT_OF_PROPER_TYPE',
     message: `${field[0].toUpperCase() + field.slice(1)} can be either of these: ${enums.toString()}.`

--- a/src/controllers/finishedQuiz.js
+++ b/src/controllers/finishedQuiz.js
@@ -25,8 +25,19 @@ const getFinishedQuizById = async (req, res) => {
   res.status(200).json(quiz)
 }
 
+const updateFinishedQuiz = async (req, res) => {
+  const { id } = req.params
+  const { id: currentUserId } = req.user
+  const updateData = req.body
+
+  await finishedQuizService.updateFinishedQuiz(id, currentUserId, updateData)
+
+  res.status(204).end()
+}
+
 module.exports = {
   getFinishedQuizzes,
   createFinishedQuiz,
-  getFinishedQuizById
+  getFinishedQuizById,
+  updateFinishedQuiz
 }

--- a/src/controllers/finishedQuiz.js
+++ b/src/controllers/finishedQuiz.js
@@ -28,9 +28,11 @@ const getFinishedQuizById = async (req, res) => {
 const updateFinishedQuiz = async (req, res) => {
   const { id } = req.params
 
+  const { role } = req.user
+
   const updateData = req.body
 
-  await finishedQuizService.updateFinishedQuiz(id, updateData)
+  await finishedQuizService.updateFinishedQuiz(id, updateData, role)
 
   res.status(204).end()
 }

--- a/src/controllers/finishedQuiz.js
+++ b/src/controllers/finishedQuiz.js
@@ -27,10 +27,10 @@ const getFinishedQuizById = async (req, res) => {
 
 const updateFinishedQuiz = async (req, res) => {
   const { id } = req.params
-  const { id: currentUserId } = req.user
+
   const updateData = req.body
 
-  await finishedQuizService.updateFinishedQuiz(id, currentUserId, updateData)
+  await finishedQuizService.updateFinishedQuiz(id, updateData)
 
   res.status(204).end()
 }

--- a/src/routes/finishedQuiz.js
+++ b/src/routes/finishedQuiz.js
@@ -14,5 +14,6 @@ router.use(authMiddleware)
 router.get('/', asyncWrapper(finishedQuizController.getFinishedQuizzes))
 router.get('/:id', asyncWrapper(finishedQuizController.getFinishedQuizById))
 router.post('/', isEntityValid({ body }), asyncWrapper(finishedQuizController.createFinishedQuiz))
+router.patch('/:id', asyncWrapper(finishedQuizController.updateFinishedQuiz))
 
 module.exports = router

--- a/src/services/finishedQuiz.js
+++ b/src/services/finishedQuiz.js
@@ -5,6 +5,10 @@ const { createError } = require('~/utils/errorsHelper')
 
 const { QUIZ_TIME_LIMIT_EXCEEDED } = require('~/consts/errors')
 
+const {
+  roles: { STUDENT }
+} = require('~/consts/auth')
+
 const finishedQuizService = {
   getFinishedQuizzes: async (author, skip = 0, limit = 10) => {
     const authorQuizzes = await Quiz.distinct('_id', { author })
@@ -44,7 +48,8 @@ const finishedQuizService = {
     }
 
     const createdAt = new Date(finishedQuiz.createdAt).getTime()
-    if (role === 'student' && !isNaN(timeLimit) && createdAt + timeLimit < Date.now()) {
+    if (role === STUDENT && !isNaN(timeLimit) && createdAt + timeLimit < Date.now()) {
+      console.log('Time limit exceeded')
       throw createError(403, QUIZ_TIME_LIMIT_EXCEEDED)
     }
 

--- a/src/services/finishedQuiz.js
+++ b/src/services/finishedQuiz.js
@@ -1,6 +1,10 @@
 const FinishedQuiz = require('~/models/finishedQuiz')
 const Quiz = require('~/models/quiz')
 
+const { createError } = require('~/utils/errorsHelper')
+
+const { QUIZ_TIME_LIMIT_EXCEEDED } = require('~/consts/errors')
+
 const finishedQuizService = {
   getFinishedQuizzes: async (author, skip = 0, limit = 10) => {
     const authorQuizzes = await Quiz.distinct('_id', { author })
@@ -28,8 +32,21 @@ const finishedQuizService = {
     return await FinishedQuiz.findById(id).lean().exec()
   },
 
-  updateFinishedQuiz: async (id, updateData) => {
+  updateFinishedQuiz: async (id, updateData, role) => {
     const finishedQuiz = await FinishedQuiz.findById(id).exec()
+    const quiz = await Quiz.findById(finishedQuiz.quiz).exec()
+
+    const timeLimitRaw = quiz.settings.timeLimit
+    let timeLimit = parseInt(timeLimitRaw)
+
+    if (!isNaN(timeLimit)) {
+      timeLimit = timeLimit === 1 ? 60 * 60 * 1000 : timeLimit * 60 * 1000
+    }
+
+    const createdAt = new Date(finishedQuiz.createdAt).getTime()
+    if (role === 'student' && !isNaN(timeLimit) && createdAt + timeLimit < Date.now()) {
+      throw createError(403, QUIZ_TIME_LIMIT_EXCEEDED)
+    }
 
     for (let field in updateData) {
       finishedQuiz[field] = updateData[field]

--- a/src/services/finishedQuiz.js
+++ b/src/services/finishedQuiz.js
@@ -1,6 +1,8 @@
 const FinishedQuiz = require('~/models/finishedQuiz')
 const Quiz = require('~/models/quiz')
 
+const { createForbiddenError } = require('~/utils/errorsHelper')
+
 const finishedQuizService = {
   getFinishedQuizzes: async (author, skip = 0, limit = 10) => {
     const authorQuizzes = await Quiz.distinct('_id', { author })
@@ -26,6 +28,21 @@ const finishedQuizService = {
 
   getFinishedQuizById: async (id) => {
     return await FinishedQuiz.findById(id).lean().exec()
+  },
+
+  updateFinishedQuiz: async (id, currentUserId, updateData) => {
+    const finishedQuiz = await FinishedQuiz.findById(id).exec()
+
+    const author = finishedQuiz.author.toString()
+    if (currentUserId !== author) {
+      throw createForbiddenError()
+    }
+
+    for (let field in updateData) {
+      finishedQuiz[field] = updateData[field]
+    }
+
+    await finishedQuiz.save()
   }
 }
 

--- a/src/services/finishedQuiz.js
+++ b/src/services/finishedQuiz.js
@@ -1,8 +1,6 @@
 const FinishedQuiz = require('~/models/finishedQuiz')
 const Quiz = require('~/models/quiz')
 
-const { createForbiddenError } = require('~/utils/errorsHelper')
-
 const finishedQuizService = {
   getFinishedQuizzes: async (author, skip = 0, limit = 10) => {
     const authorQuizzes = await Quiz.distinct('_id', { author })
@@ -30,13 +28,8 @@ const finishedQuizService = {
     return await FinishedQuiz.findById(id).lean().exec()
   },
 
-  updateFinishedQuiz: async (id, currentUserId, updateData) => {
+  updateFinishedQuiz: async (id, updateData) => {
     const finishedQuiz = await FinishedQuiz.findById(id).exec()
-
-    const author = finishedQuiz.author.toString()
-    if (currentUserId !== author) {
-      throw createForbiddenError()
-    }
 
     for (let field in updateData) {
       finishedQuiz[field] = updateData[field]

--- a/src/services/finishedQuiz.js
+++ b/src/services/finishedQuiz.js
@@ -49,7 +49,6 @@ const finishedQuizService = {
 
     const createdAt = new Date(finishedQuiz.createdAt).getTime()
     if (role === STUDENT && !isNaN(timeLimit) && createdAt + timeLimit < Date.now()) {
-      console.log('Time limit exceeded')
       throw createError(403, QUIZ_TIME_LIMIT_EXCEEDED)
     }
 

--- a/src/test/integration/controllers/finishedQuiz.spec.js
+++ b/src/test/integration/controllers/finishedQuiz.spec.js
@@ -145,7 +145,9 @@ describe('Quiz controller', () => {
       })
 
       it('should throw UNAUTHORIZED', async () => {
-        const response = await app.get(endpointUrl)
+        const finishedQuizId = testFinishedQuiz._body._id
+
+        const response = await app.get(endpointUrl + finishedQuizId)
 
         expectError(401, UNAUTHORIZED, response)
       })
@@ -168,7 +170,7 @@ describe('Quiz controller', () => {
       })
 
       it('should throw UNAUTHORIZED', async () => {
-        const response = await app.get(endpointUrl)
+        const response = await app.patch(endpointUrl)
 
         expectError(401, UNAUTHORIZED, response)
       })

--- a/src/test/integration/controllers/finishedQuiz.spec.js
+++ b/src/test/integration/controllers/finishedQuiz.spec.js
@@ -149,5 +149,28 @@ describe('Quiz controller', () => {
 
         expectError(401, UNAUTHORIZED, response)
       })
+    }),
+    describe(`PATCH ${endpointUrl}:id`, () => {
+      it('should update finished quiz', async () => {
+        const finishedQuizId = testFinishedQuiz._body._id
+
+        const response = await app
+          .patch(endpointUrl + finishedQuizId)
+          .send({ grade: 88 })
+          .set('Cookie', [`accessToken=${accessToken}`])
+
+        const updatedFinishedQuiz = await app
+          .get(endpointUrl + finishedQuizId)
+          .set('Cookie', [`accessToken=${accessToken}`])
+
+        expect(response.statusCode).toBe(204)
+        expect(updatedFinishedQuiz._body.grade).toEqual(88)
+      })
+
+      it('should throw UNAUTHORIZED', async () => {
+        const response = await app.get(endpointUrl)
+
+        expectError(401, UNAUTHORIZED, response)
+      })
     })
 })

--- a/src/test/integration/controllers/finishedQuiz.spec.js
+++ b/src/test/integration/controllers/finishedQuiz.spec.js
@@ -6,7 +6,7 @@ const Quiz = require('~/models/quiz')
 const testUserAuthentication = require('~/utils/testUserAuth')
 const { UNAUTHORIZED, DOCUMENT_NOT_FOUND } = require('~/consts/errors')
 const {
-  roles: { TUTOR }
+  roles: { TUTOR, STUDENT }
 } = require('~/consts/auth')
 const TokenService = require('~/services/token')
 
@@ -38,7 +38,10 @@ const testQuizData = {
   title: 'Assembly',
   description: 'Description',
   category: '6502ec2060ec37be943353e2',
-  items: ['6527ed6c14c6b72f36962364']
+  items: ['6527ed6c14c6b72f36962364'],
+  settings: {
+    timeLimit: '15 minutes'
+  }
 }
 
 describe('Quiz controller', () => {
@@ -175,4 +178,53 @@ describe('Quiz controller', () => {
         expectError(401, UNAUTHORIZED, response)
       })
     })
+})
+
+describe('Finished quiz controller for student', () => {
+  let app, server, accessToken, currentUser, testQuiz
+
+  beforeAll(async () => {
+    ;({ app, server } = await serverInit())
+  })
+
+  beforeEach(async () => {
+    accessToken = await testUserAuthentication(app, { role: STUDENT })
+
+    currentUser = TokenService.validateAccessToken(accessToken)
+
+    testQuiz = await Quiz.create({
+      author: currentUser.id,
+      ...testQuizData
+    })
+  })
+
+  afterEach(async () => {
+    await serverCleanup()
+  })
+
+  afterAll(async () => {
+    await stopServer(server)
+  })
+
+  describe(`PATCH ${endpointUrl}:id`, () => {
+    it('should throw QUIZ_TIME_LIMIT_EXCEEDED when time limit exceeded', async () => {
+      const testFinishedQuiz = await app
+        .post(endpointUrl)
+        .send({ quiz: testQuiz._id, ...testFinishedQuizData })
+        .set('Cookie', [`accessToken=${accessToken}`])
+      const finishedQuizId = testFinishedQuiz._body._id
+
+      const createdAt = new Date(testFinishedQuiz._body.createdAt).getTime()
+      const timeLimitInMilliseconds = 15 * 60 * 1000
+      const timePassed = timeLimitInMilliseconds + 1
+      jest.spyOn(Date, 'now').mockImplementation(() => createdAt + timePassed)
+
+      const response = await app
+        .patch(endpointUrl + finishedQuizId)
+        .send({ grade: 88 })
+        .set('Cookie', [`accessToken=${accessToken}`])
+
+      expect(response.statusCode).toBe(403)
+    })
+  })
 })


### PR DESCRIPTION
Now we have an endpoint for editing the finished quizzes.


Successful editing of the finished quiz:
<img width="1200" alt="Screenshot 2025-02-06 at 12 28 34" src="https://github.com/user-attachments/assets/ec4f3035-abe5-4a3b-8bfe-e184943fe1a6" />


The student can't edit the finished quiz after the time limit is exceeded:
<img width="1153" alt="Screenshot 2025-02-06 at 12 29 55" src="https://github.com/user-attachments/assets/3a64da59-c9d9-4a52-9c03-8a602361405a" />


Also, I've fixed the swagger issue with the invalid ID casting for /quizzes and /finished-quizzes.

