### PR TITLE
Fix incorrect field assignments in Course schemas

### DIFF
--- a/docs/attachments/attachments-schema.yaml
+++ b/docs/attachments/attachments-schema.yaml
@@ -90,7 +90,7 @@ definitions:
       link:
         type: string
       category:
-        $ref: '#/definitions/lessonCategory'
+        $ref: '#/definitions/categoryWithName'
       resourceType:
         $ref: '#/definitions/resourceType'
       size:

--- a/docs/category/category-schema.yaml
+++ b/docs/category/category-schema.yaml
@@ -113,3 +113,10 @@ definitions:
             type: string
           color:
             type: string
+  categoryWithName:
+    type: object
+    properties:
+      _id:
+        type: string
+      name:
+        type: string

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -93,12 +93,7 @@ definitions:
                 type: object
                 properties:
                   resource:
-                    type: object
-                    oneOf:
-                      - $ref: '#/definitions/lessonInCourse'
-                      - $ref: '#/definitions/quizInCourse'
-                      - $ref: '#/definitions/attachmentInCourse'
-                      - $ref: '#/definitions/question'
+                    $ref: '#/definitions/resourcesInLesson'
                   resourceType:
                     $ref: '#/definitions/resourceType'
                 required:
@@ -128,12 +123,7 @@ definitions:
             type: object
             properties:
               resource:
-                type: object
-                oneOf:
-                  - $ref: '#/definitions/lessonInCourse'
-                  - $ref: '#/definitions/quizInCourse'
-                  - $ref: '#/definitions/attachmentInCourse'
-                  - $ref: '#/definitions/question'
+                $ref: '#/definitions/resourcesInLesson'
               resourceType:
                 $ref: '#/definitions/resourceType'
         _id:
@@ -199,3 +189,9 @@ definitions:
           isDuplicate:
             type: boolean
             description: 'Only present when the resource is a copy'
+  resourcesInLesson:
+    oneOf:
+      - $ref: '#/definitions/lessonInCourse'
+      - $ref: '#/definitions/quizInCourse'
+      - $ref: '#/definitions/attachmentInCourse'
+      - $ref: '#/definitions/question'

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -123,7 +123,7 @@ definitions:
             type: object
             properties:
               resource:
-                $ref: '#/definitions/resourcesInLesson'
+                $ref: '#/definitions/resourcesInCourse'
               resourceType:
                 $ref: '#/definitions/resourceType'
         _id:
@@ -189,7 +189,7 @@ definitions:
           isDuplicate:
             type: boolean
             description: 'Only present when the resource is a copy'
-  resourcesInLesson:
+  resourcesInCourse:
     oneOf:
       - $ref: '#/definitions/lessonInCourse'
       - $ref: '#/definitions/quizInCourse'

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -182,7 +182,7 @@ definitions:
         format: date-time
       isDuplicate:
         type: boolean
-        description: 'Only present when the resource is a copy'
+        description: Only present when the resource is a copy
   lessonInCourse:
     allOf:
       - $ref: '#/definitions/lesson'
@@ -190,7 +190,7 @@ definitions:
         properties:
           isDuplicate:
             type: boolean
-            description: 'Only present when the resource is a copy'
+            description: Only present when the resource is a copy
   attachmentInCourse:
     allOf:
       - $ref: '#/definitions/attachmentInPostLesson'

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -92,6 +92,9 @@ definitions:
                       - $ref: '#/definitions/question'
                   resourceType:
                     $ref: '#/definitions/resourceType'
+                required:
+                  - resource
+                  - resourceType
           required:
             - title
             - description
@@ -99,6 +102,8 @@ definitions:
     required:
       - title
       - description
+      - subject
+      - proficiencyLevel
   courseSections:
     type: array
     items:
@@ -171,7 +176,7 @@ definitions:
         description: 'Only present when the resource is a copy'
   lessonInCourse:
     allOf:
-      - $ref: '#/definitions/baseLesson'
+      - $ref: '#/definitions/lesson'
       - type: object
         properties:
           isDuplicate:

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -1,62 +1,36 @@
 definitions:
   courses:
-    type: array
-    items:
-      type: object
-      properties:
-        _id:
-          type: string
-        title:
-          type: string
-        description:
-          type: string
-        author:
-          type: string
-          ref: '#components/user'
-        category:
-          type: string
-          ref: '#components/category'
-        subject:
-          type: string
-          ref: '#components/subject'
-        proficiencyLevel:
-          type: array
-          items:
-            type: string
-            enum:
-              - Beginner
-              - Intermediate
-              - Advanced
-              - Test Preparation
-              - Professional
-              - Specialized
-        sections:
-          type: array
-          items:
-            type: object
-            properties:
-            title: string
-            description: string
-            resources:
-              type: array
-              items:
-                type: object
-                properties:
-                  resource:
-                    type: object
-                    additionalProperties: true
-                  resourceType:
-                    type: string
-                    enum:
-                      - lesson
-                      - quiz
-                      - attachment
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
+    type: object
+    properties:
+      count:
+        type: number
+      items:
+        type: array
+        items:
+          type: object
+          properties:
+            _id:
+              type: string
+            title:
+              type: string
+            description:
+              type: string
+            author:
+              type: string
+            category:
+              $ref: '#/definitions/categoryWithAppearance'
+            subject:
+              $ref: '#/definitions/subjectWithName'
+            proficiencyLevel:
+              $ref: '#/definitions/offerProficiencyLevelValues'
+            sections:
+              $ref: '#/definitions/courseSections'
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
   course:
     type: object
     properties:
@@ -68,48 +42,14 @@ definitions:
         type: string
       author:
         type: string
-        ref: '#components/user'
       category:
         type: string
-        ref: '#components/category'
       subject:
         type: string
-        ref: '#components/subject'
       proficiencyLevel:
-        type: array
-        items:
-          type: string
-          enum:
-            - Beginner
-            - Intermediate
-            - Advanced
-            - Test Preparation
-            - Professional
-            - Specialized
+        $ref: '#/definitions/offerProficiencyLevelValues'
       sections:
-        type: array
-        items:
-          type: object
-          properties:
-            _id:
-              type: string
-            title:
-              type: string
-            description:
-              type: string
-            resources:
-              type: array
-              items:
-                type: object
-                properties:
-                  resource:
-                    type: string
-                  resourceType:
-                    type: string
-                    enum:
-                      - lesson
-                      - quiz
-                      - attachment
+        $ref: '#/definitions/courseSections'
       createdAt:
         type: string
         format: date-time
@@ -125,21 +65,10 @@ definitions:
         type: string
       category:
         type: string
-        ref: '#components/category'
       subject:
         type: string
-        ref: '#components/subject'
       proficiencyLevel:
-        type: array
-        items:
-          type: string
-          enum:
-            - Beginner
-            - Intermediate
-            - Advanced
-            - Test Preparation
-            - Professional
-            - Specialized
+        $ref: '#/definitions/offerProficiencyLevelValues'
       sections:
         type: array
         items:
@@ -156,43 +85,13 @@ definitions:
                 properties:
                   resource:
                     type: object
-                    properties:
-                      title:
-                        type: string
-                      description:
-                        type: string
-                      content:
-                        type: string
-                      author:
-                        type: string
-                      attachments:
-                        type: array
-                        items:
-                          type: string
-                      category:
-                        type: object
-                        properties:
-                          _id:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                          - _id
-                          - name
-                      _id:
-                        type: string
-                    required:
-                      - title
-                      - description
-                      - content
-                      - author
-                      - _id
+                    oneOf:
+                      - $ref: '#/definitions/lessonInCourse'
+                      - $ref: '#/definitions/quizInCourse'
+                      - $ref: '#/definitions/attachmentInCourse'
+                      - $ref: '#/definitions/question'
                   resourceType:
-                    type: string
-                    enum:
-                      - lesson
-                      - quiz
-                      - attachment
+                    $ref: '#/definitions/resourceType'
           required:
             - title
             - description
@@ -200,3 +99,89 @@ definitions:
     required:
       - title
       - description
+  courseSections:
+    type: array
+    items:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        resources:
+          type: array
+          items:
+            type: object
+            properties:
+              resource:
+                type: object
+                oneOf:
+                  - $ref: '#/definitions/lessonInCourse'
+                  - $ref: '#/definitions/quizInCourse'
+                  - $ref: '#/definitions/attachmentInCourse'
+                  - $ref: '#/definitions/question'
+              resourceType:
+                $ref: '#/definitions/resourceType'
+        _id:
+          type: string
+  quizInCourse:
+    type: object
+    properties:
+      _id:
+        type: string
+      title:
+        type: string
+      description:
+        type: string
+      items:
+        type: array
+        items:
+          type: string
+      author:
+        type: string
+      category:
+        $ref: '#/definitions/categoryWithName'
+      resourceType:
+        $ref: '#/definitions/resourceType'
+      settings:
+        type: object
+        properties:
+          view:
+            $ref: '#/definitions/view'
+          timeLimit:
+            $ref: '#/definitions/timeLimit'
+          attemptLimit:
+            $ref: '#/definitions/attemptLimit'
+          shuffle:
+            type: boolean
+          pointValues:
+            type: boolean
+          scoredResponses:
+            type: boolean
+          correctAnswers:
+            type: boolean
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
+      isDuplicate:
+        type: boolean
+        description: 'Only present when the resource is a copy'
+  lessonInCourse:
+    allOf:
+      - $ref: '#/definitions/baseLesson'
+      - type: object
+        properties:
+          isDuplicate:
+            type: boolean
+            description: 'Only present when the resource is a copy'
+  attachmentInCourse:
+    allOf:
+      - $ref: '#/definitions/attachmentInPostLesson'
+      - type: object
+        properties:
+          isDuplicate:
+            type: boolean
+            description: 'Only present when the resource is a copy'

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -61,10 +61,15 @@ definitions:
     properties:
       title:
         type: string
+        minLength: 1
+        maxLength: 100
       description:
         type: string
+        minLength: 1
+        maxLength: 1000
       category:
         type: string
+        nullable: true
       subject:
         type: string
       proficiencyLevel:
@@ -76,8 +81,12 @@ definitions:
           properties:
             title:
               type: string
+              minLength: 1
+              maxLength: 100
             description:
               type: string
+              minLength: 1
+              maxLength: 150
             resources:
               type: array
               items:

--- a/docs/course/course-schema.yaml
+++ b/docs/course/course-schema.yaml
@@ -93,7 +93,7 @@ definitions:
                 type: object
                 properties:
                   resource:
-                    $ref: '#/definitions/resourcesInLesson'
+                    $ref: '#/definitions/resourcesInCourse'
                   resourceType:
                     $ref: '#/definitions/resourceType'
                 required:

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -26,7 +26,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/course'
+                $ref: '#/definitions/courses'
               example:
                 - _id: 64045f98b131dd04d7896af6
                   title: Advanced English

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -81,8 +81,8 @@ paths:
                             _id: 63ed1cd25e9d781cdb6a6b15
                             author: 648afee884936e09a37deaaa
                             fileName: EnglishB2Level
-                            link: 'https://english-b2-test.com'
-                            size: 230,
+                            link: https://english-b2-test.com
+                            size: 230
                             category:
                               _id: 6477007a6fa4d05e1a800ce1
                               name: Science
@@ -115,8 +115,8 @@ paths:
                             _id: 63ed1cd25e9d781cdb6a6b16
                             author: 648afee884936e09a37deaaa
                             fileName: UkrainianAdvanced
-                            link: 'https://ukrainian-prof-test.com'
-                            size: 230,
+                            link: https://ukrainian-prof-test.com
+                            size: 230
                             category:
                               _id: 6477007a6fa4d05e1a800ce1
                               name: Languages
@@ -173,10 +173,10 @@ paths:
                   description: some description
                   resources:
                     - resource:
-                        title: Colors in English,
-                        description: With this lesson you will learn all about colors in English.,
-                        content: <h1>Title</h1>,
-                        author: 63da8767c9ad4c9a0b0eacd3,
+                        title: Colors in English
+                        description: With this lesson you will learn all about colors in English.
+                        content: <h1>Title</h1>
+                        author: 63da8767c9ad4c9a0b0eacd3
                         attachments:
                           - 63ed1cd25e9d781cdb6a6b15
                         category:
@@ -327,10 +327,10 @@ paths:
                     description: some description
                     resources:
                       - resource:
-                          title: Colors in English,
-                          description: With this lesson you will learn all about colors in English.,
-                          content: <h1>Title</h1>,
-                          author: 63da8767c9ad4c9a0b0eacd3,
+                          title: Colors in English
+                          description: With this lesson you will learn all about colors in English.
+                          content: <h1>Title</h1>
+                          author: 63da8767c9ad4c9a0b0eacd3
                           attachments:
                             - 63ed1cd25e9d781cdb6a6b15
                           category:

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -160,7 +160,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#definitions/courseBody'
+              $ref: '#/definitions/courseBody'
             example:
               title: Advanced English
               description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.

--- a/docs/course/course.yaml
+++ b/docs/course/course.yaml
@@ -33,76 +33,99 @@ paths:
                   description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
                   author: 63da8767c9ad4c9a0b0eacd3
                   category:
-                    { _id: 64884f33fdc2d1a130c24ac2, appearance: { icon: 'mocked-path-to-icon', color: '#66C42C' } }
-                  subject: { _id: 6488509cfdc2d1a130c24ae4, name: Languages }
-                  proficiencyLevel: [Advanced]
+                    _id: 64884f33fdc2d1a130c24ac2
+                    appearance:
+                      icon: mocked-path-to-icon
+                      color: '#66C42C'
+                  subject:
+                    _id: 6488509cfdc2d1a130c24ae4
+                    name: Languages
+                  proficiencyLevel:
+                    - Advanced
                   sections:
                     - title: Section First
                       description: some description
                       resources:
-                        [
-                          {
-                            resource:
-                              {
-                                title: Colors in English,
-                                description: With this lesson you will learn all about colors in English.,
-                                content: <h1>Title</h1>,
-                                author: 63da8767c9ad4c9a0b0eacd3,
-                                attachments: [63ed1cd25e9d781cdb6a6b15],
-                                category: { _id: 6477007a6fa4d05e1a800ce1, name: Languages },
-                                _id: 63ed1cd25e9d781cdb6a6b17
-                              },
+                        - resource:
+                            title: Colors in English
+                            description: With this lesson you will learn all about colors in English.
+                            content: <h1>Title</h1>
+                            author: 63da8767c9ad4c9a0b0eacd3
+                            attachments:
+                              - 63ed1cd25e9d781cdb6a6b15
+                            category:
+                              _id: 6477007a6fa4d05e1a800ce1
+                              name: Languages
+                            _id: 63ed1cd25e9d781cdb6a6b17
                             resourceType: lesson
-                          },
-                          {
-                            resource:
-                              {
-                                _id: 64ba39c714b7bc037a29d712,
-                                title: Title,
-                                description: description,
-                                items: [6477007a6fa4d05e1a800ce4, 6477007a6fa4d05e1a800ce6],
-                                author: '6477007a6fa4d05e1a800ce5',
-                                category: '63bed9ef260f18d04ab15da',
-                                settings:
-                                  {
-                                    view: Scroll,
-                                    shuffle: true,
-                                    pointValues: false,
-                                    scoredResponses: false,
-                                    correctAnswers: true
-                                  }
-                              },
-                            resourceType: quiz
-                          },
-                          {
-                            resource:
-                              {
-                                _id: 63ed1cd25e9d781cdb6a6b15,
-                                author: 648afee884936e09a37deaaa,
-                                fileName: EnglishB2Level,
-                                link: 'https://english-b2-test.com',
-                                size: 230,
-                                category: { _id: 6477007a6fa4d05e1a800ce1, name: Science }
-                              },
+                            createdAt: 2023-12-01T13:25:36.292Z
+                            updatedAt: 2023-12-01T13:25:36.292Z
+                          resourceType: lesson
+                        - resource:
+                            _id: 64ba39c714b7bc037a29d712
+                            title: Title
+                            description: description
+                            items:
+                              - 6477007a6fa4d05e1a800ce4
+                              - 6477007a6fa4d05e1a800ce6
+                            author: 6477007a6fa4d05e1a800ce5
+                            category: 63bed9ef260f18d04ab15da
+                            settings:
+                              view: Scroll
+                              shuffle: true
+                              pointValues: false
+                              scoredResponses: false
+                              correctAnswers: true
+                          resourceType: quiz
+                        - resource:
+                            _id: 63ed1cd25e9d781cdb6a6b15
+                            author: 648afee884936e09a37deaaa
+                            fileName: EnglishB2Level
+                            link: 'https://english-b2-test.com'
+                            size: 230,
+                            category:
+                              _id: 6477007a6fa4d05e1a800ce1
+                              name: Science
                             resourceType: attachment
-                          }
-                        ]
+                            createdAt: 2023-12-01T13:25:36.292Z
+                            updatedAt: 2023-12-01T13:25:36.292Z
+                          resourceType: attachment
+                      _id: 640461e3cfdda3f3d16dcac7
                   createdAt: 2023-11-15T16:15:09.004Z
                   updatedAt: 2023-11-15T16:15:09.004Z
                 - _id: 640461e3cfdda3f3d16dcac5
                   title: Advanced Ukrainian
                   description: Advanced Ukrainian course with 5 modules and separated lessons for improving speaking, listening and reading.
                   author: 63da8767c9ad4c9a0b0eacd3
-                  category: 64884f33fdc2d1a130c24ac2
-                  subject: 6488509cfdc2d1a130c24ae4
-                  proficiencyLevel: [Advanced]
+                  category:
+                    _id: 64884f33fdc2d1a130c24ac2
+                    appearance:
+                      icon: mocked-path-to-icon
+                      color: '#66C42C'
+                  subject:
+                    _id: 6488509cfdc2d1a130c24ae4
+                    name: Languages
+                  proficiencyLevel:
+                    - Advanced
                   sections:
                     - title: Section Second
                       description: some description
                       resources:
-                        [{ resource: { fileName: Attachment1, link: '170-Attachment1.pdf' }, resourceType: attachment }]
-                  createdAt: 2023-20-01T13:25:36.292Z
-                  updatedAt: 2023-20-01T13:25:36.292Z
+                        - resource:
+                            _id: 63ed1cd25e9d781cdb6a6b16
+                            author: 648afee884936e09a37deaaa
+                            fileName: UkrainianAdvanced
+                            link: 'https://ukrainian-prof-test.com'
+                            size: 230,
+                            category:
+                              _id: 6477007a6fa4d05e1a800ce1
+                              name: Languages
+                            resourceType: attachment
+                            createdAt: 2023-12-01T13:25:36.292Z
+                            updatedAt: 2023-12-01T13:25:36.292Z
+                          resourceType: attachment
+                  createdAt: 2023-12-01T13:25:36.292Z
+                  updatedAt: 2023-12-01T13:25:36.292Z
         401:
           description: Unauthorized
           content:
@@ -143,26 +166,25 @@ paths:
               description: Advanced english course with 5 modules and separated lessons for improving speaking, listening and reading.
               category: 64884f33fdc2d1a130c24ac2
               subject: 6488509cfdc2d1a130c24ae4
-              proficiencyLevel: [Advanced]
+              proficiencyLevel:
+                - Advanced
               sections:
                 - title: Section First
                   description: some description
                   resources:
-                    [
-                      {
-                        resource:
-                          {
-                            title: Colors in English,
-                            description: With this lesson you will learn all about colors in English.,
-                            content: <h1>Title</h1>,
-                            author: 63da8767c9ad4c9a0b0eacd3,
-                            attachments: [63ed1cd25e9d781cdb6a6b15],
-                            category: { _id: 6477007a6fa4d05e1a800ce1, name: Languages },
-                            _id: 63ed1cd25e9d781cdb6a6b17
-                          },
+                    - resource:
+                        title: Colors in English,
+                        description: With this lesson you will learn all about colors in English.,
+                        content: <h1>Title</h1>,
+                        author: 63da8767c9ad4c9a0b0eacd3,
+                        attachments:
+                          - 63ed1cd25e9d781cdb6a6b15
+                        category:
+                          _id: 6477007a6fa4d05e1a800ce1
+                          name: Languages
+                        _id: 63ed1cd25e9d781cdb6a6b17
                         resourceType: lesson
-                      }
-                    ]
+                      resourceType: lesson
       responses:
         201:
           description: Created
@@ -176,12 +198,15 @@ paths:
                 author: 63da8767c9ad4c9a0b0eacd3
                 category: 64884f33fdc2d1a130c24ac2
                 subject: 6488509cfdc2d1a130c24ae4
-                proficiencyLevel: [Advanced]
+                proficiencyLevel:
+                  - Advanced
                 sections:
                   - _id: 6781349b8c7432471f221116
                     title: Section First
                     description: some description
-                    resources: [{ resource: 63ed1cd25e9d781cdb6a6b17, resourceType: lesson }]
+                    resources:
+                      - resource: 63ed1cd25e9d781cdb6a6b17
+                        resourceType: lesson
                 _id: 63ec1cd51e9d781cdb6f4b14
                 createdAt: 2023-02-14T23:44:21.334Z
                 updatedAt: 2023-02-14T23:44:21.334Z
@@ -295,26 +320,27 @@ paths:
                 author: 63da8767c9ad4c9a0b0eacd3
                 category: 64884f33fdc2d1a130c24ac2
                 subject: 6488509cfdc2d1a130c24ae4
-                proficiencyLevel: [Advanced]
+                proficiencyLevel:
+                  - Advanced
                 sections:
                   - title: Section First
                     description: some description
                     resources:
-                      [
-                        {
-                          resource:
-                            {
-                              title: Colors in English,
-                              description: With this lesson you will learn all about colors in English.,
-                              content: <h1>Title</h1>,
-                              author: 63da8767c9ad4c9a0b0eacd3,
-                              attachments: [63ed1cd25e9d781cdb6a6b15],
-                              category: { _id: 6477007a6fa4d05e1a800ce1, name: Languages },
-                              _id: 63ed1cd25e9d781cdb6a6b17
-                            },
+                      - resource:
+                          title: Colors in English,
+                          description: With this lesson you will learn all about colors in English.,
+                          content: <h1>Title</h1>,
+                          author: 63da8767c9ad4c9a0b0eacd3,
+                          attachments:
+                            - 63ed1cd25e9d781cdb6a6b15
+                          category:
+                            _id: 6477007a6fa4d05e1a800ce1
+                            name: Languages
+                          _id: 63ed1cd25e9d781cdb6a6b17
                           resourceType: lesson
-                        }
-                      ]
+                          createdAt: 2023-02-14T23:44:21.334Z
+                          updatedAt: 2023-02-14T23:44:21.334Z
+                        resourceType: lesson
                 _id: 63ec1cd51e9d781cdb6f4b14
                 createdAt: 2023-02-14T23:44:21.334Z
                 updatedAt: 2023-02-14T23:44:21.334Z

--- a/docs/lesson/lesson-schema.yaml
+++ b/docs/lesson/lesson-schema.yaml
@@ -13,7 +13,7 @@ definitions:
       content:
         type: string
       category:
-        $ref: '#/definitions/lessonCategory'
+        $ref: '#/definitions/categoryWithName'
       resourceType:
         $ref: '#/definitions/resourceType'
       createdAt:
@@ -68,11 +68,4 @@ definitions:
         items:
           $ref: '#/definitions/attachmentInPostLesson'
       category:
-        type: string
-  lessonCategory:
-    type: object
-    properties:
-      _id:
-        type: string
-      name:
         type: string


### PR DESCRIPTION
Updated `Course` schemas:
1. `courses`:
<img width="975" alt="Screenshot 2025-02-15 at 14 23 00" src="https://github.com/user-attachments/assets/f03fc223-5950-4632-b17b-66b663124db8" />
sections in courses:
<img width="907" alt="Screenshot 2025-02-19 at 16 11 06" src="https://github.com/user-attachments/assets/528e4e92-a5f5-48d8-8a14-50a637bd172d" />
2. `courseBody`
<img width="928" alt="Screenshot 2025-02-19 at 16 08 11" src="https://github.com/user-attachments/assets/eb5e4ae6-f5b4-4d0a-aa0c-cdda7c67bded" />
3. `course`:
<img width="929" alt="Screenshot 2025-02-15 at 15 21 50" src="https://github.com/user-attachments/assets/4548d140-e2e6-4fcc-b122-5400d70f8118" />
-------------------------------------------

- [x] Added new schemas
- [x] Updated examples to reflect the new schema changes
- [x] Fixed formatting


