### PR TITLE
chore(Dockerfile): update Node.js base image and improve dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM node:14-alpine
+FROM node:lts-alpine3.20
 ARG MONGODB_URL
 WORKDIR /app
 COPY package.json .
+# TODO change to npm ci, need a valid package-lock.json
 RUN npm install
 COPY . .
 EXPOSE 8080


### PR DESCRIPTION
- Upgraded Node.js base image from `node:14-alpine` to `node:lts-alpine3.20`
- Added a TODO to replace `npm install` with `npm ci` for reproducible builds
- Ensured `CMD` consistency (no functional changes)

This improves security and compatibility while preparing for a more stable dependency installation process.