### PR TITLE
Added logic to calculate completedResourcesPercentage

### DIFF
--- a/src/utils/cooperations/getCooperationByIdQueryPipeline.js
+++ b/src/utils/cooperations/getCooperationByIdQueryPipeline.js
@@ -185,6 +185,34 @@ const getCooperationByIdQueryPipeline = (id, isClosedResourcesHidden) => {
         },
         sectionOrder: {
           $first: '$sectionOrder'
+        },
+        completedResourcesCount: {
+          $sum: {
+            $cond: [
+              {
+                $and: [
+                  { $eq: ['$sections.resources.completionStatus', 'completed'] },
+                  { $eq: ['$sections.resources.availability.status', 'open'] }
+                ]
+              },
+              1,
+              0
+            ]
+          }
+        },
+        totalResourcesCount: {
+          $sum: {
+            $cond: [
+              {
+                $and: [
+                  { $ifNull: ['$sections.resources', false] },
+                  { $eq: ['$sections.resources.availability.status', 'open'] }
+                ]
+              },
+              1,
+              0
+            ]
+          }
         }
       }
     },
@@ -222,6 +250,17 @@ const getCooperationByIdQueryPipeline = (id, isClosedResourcesHidden) => {
       }
     },
     {
+      $set: {
+        completedResourcesPercentage: {
+          $cond: {
+            if: { $gt: ['$totalResourcesCount', 0] },
+            then: { $floor: { $multiply: [{ $divide: ['$completedResourcesCount', '$totalResourcesCount'] }, 100] } },
+            else: 0
+          }
+        }
+      }
+    },
+    {
       $group: {
         ...commonGroupFields,
         _id: '$_id',
@@ -233,6 +272,9 @@ const getCooperationByIdQueryPipeline = (id, isClosedResourcesHidden) => {
         },
         updatedAt: {
           $first: '$updatedAt'
+        },
+        completedResourcesPercentage: {
+          $first: '$completedResourcesPercentage'
         }
       }
     },


### PR DESCRIPTION
Updated `getCooperationByIdQueryPipeline` to include the percentage of completed resources (`completedResourcesPercentage`) when fetching cooperation data.
The completedResourcesPercentage field is now calculated dynamically in the aggregation pipeline, ensuring that the response includes an accurate progress value.

- Added $set stage in the aggregation pipeline to compute `completedResourcesPercentage`.
- Excluded resources marked as "closed" from `totalResourcesCount` to ensure accurate calculations.
- Ensures that if `totalResourcesCount` is 0, the percentage defaults to 0 to prevent division errors.
<img width="377" alt="Screenshot 2025-03-17 at 16 49 13" src="https://github.com/user-attachments/assets/efa013ea-6711-49d0-907f-7dea4cb6acb5" />


The frontend can now directly use the `completedResourcesPercentage` field without additional calculations.
