### PR TITLE
Increase test coverage in chat controller

### DIFF
--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -192,7 +192,9 @@ describe('Auth controller', () => {
         .split('=')[1]
 
       const decodedRefreshToken = jwt.decode(refreshToken)
-      expect(decodedRefreshToken.exp).toBe(30 * 24 * 60 * 60 + Math.floor(Date.now() / 1000))
+      const expectedExp = 30 * 24 * 60 * 60 + Math.floor(Date.now() / 1000)
+      const tolerance = 1
+      expect(Math.abs(decodedRefreshToken.exp - expectedExp)).toBeLessThanOrEqual(tolerance)
     })
 
     it('should throw INCORRECT_CREDENTIALS error', async () => {

--- a/src/test/integration/controllers/chat.spec.js
+++ b/src/test/integration/controllers/chat.spec.js
@@ -111,6 +111,29 @@ describe('Chat controller', () => {
     })
   })
 
+  describe(`GET ${endpointUrl}`, () => {
+    it('should return chats for current user', async () => {
+      const response = await app.get(endpointUrl).set('Cookie', [`accessToken=${accessToken}`])
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toEqual([
+        expect.objectContaining({
+          _id: expect.any(String),
+          members: expect.any(Array),
+          deletedFor: expect.any(Array),
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String)
+        })
+      ])
+    })
+
+    it('should return UNAUTHORIZED if no token', async () => {
+      const response = await app.get(endpointUrl)
+
+      expectError(401, UNAUTHORIZED, response)
+    })
+  })
+
   describe(`DELETE ${endpointUrl}:id`, () => {
     it('should throw FORBIDDEN', async () => {
       const response = await app


### PR DESCRIPTION
I add test for GET endpoint in chat controller here

RESULT:

<img width="636" alt="Знімок екрана 2025-04-10 о 16 27 00" src="https://github.com/user-attachments/assets/471d4318-8b0a-428a-9f1c-ff160418f6de" />


And do some changes in auth controller test,  because before i have not passed test there
IDK why, but now all good
