### PR TITLE
Store and Return Full URL for Uploaded Attachments

### DIFF
--- a/src/services/attachment.js
+++ b/src/services/attachment.js
@@ -101,7 +101,7 @@ const attachmentService = {
     await Attachment.findByIdAndRemove(id)
   },
 
-  deleteAttachementsByAuthor: async (author) => {
+  deleteAttachmentsByAuthor: async (author) => {
     await Attachment.deleteMany({ author })
   }
 }

--- a/src/services/upload.js
+++ b/src/services/upload.js
@@ -23,7 +23,7 @@ const uploadService = {
     blockBlobClient = containerClient.getBlockBlobClient(blobName)
     try {
       await blockBlobClient.uploadData(buffer)
-      return blobName
+      return blockBlobClient.url
     } catch (error) {
       throw new Error(`Failed to upload file: ${error.message}`)
     }

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -294,7 +294,7 @@ const userService = {
   deleteUser: async (id) => {
     await Promise.all([
       notificationService.clearNotifications(id),
-      attachmentService.deleteAttachementsByAuthor(id),
+      attachmentService.deleteAttachmentsByAuthor(id),
       lessonService.deleteLessonsByAuthor(id),
       quizService.deleteQuizzesByAuthor(id),
       questionService.deleteQuestionsByAuthor(id),

--- a/src/test/integration/controllers/attachments.spec.js
+++ b/src/test/integration/controllers/attachments.spec.js
@@ -39,6 +39,13 @@ jest.mock('@azure/storage-blob', () => {
   }
 })
 
+jest.mock('~/services/upload', () => {
+  return {
+    uploadFile: jest.fn(() => Promise.resolve('mocked-link')),
+    updateFile: jest.fn(() => {})
+  }
+})
+
 const testFile = {
   originalname: 'example.pdf',
   description: 'Here is everything you need to study this subject.',

--- a/src/test/unit/services/upload.spec.js
+++ b/src/test/unit/services/upload.spec.js
@@ -15,7 +15,8 @@ describe('uploadService', () => {
   it('Should upload a file to Azure Blob Storage', async () => {
     const uploadDataMock = jest.fn().mockResolvedValue({})
     const getBlockBlobClientMock = jest.fn(() => ({
-      uploadData: uploadDataMock
+      uploadData: uploadDataMock,
+      url: `mock-url/${fileName}`
     }))
     const getContainerClientMock = jest.fn(() => ({
       getBlockBlobClient: getBlockBlobClientMock
@@ -26,10 +27,8 @@ describe('uploadService', () => {
       getContainerClient: getContainerClientMock
     }))
 
-    const blobName = `${file.name}`
-
     const result = await uploadService.uploadFile(file.name, file.buffer, 'container')
-    expect(result).toContain(blobName)
+    expect(result).toMatch(new RegExp(`.*${fileName}$`))
   })
 
   it('Should show an err during the upload', async () => {


### PR DESCRIPTION
Updated the upload attachment flow:

- [x] Updated the uploadService.uploadFile method to return the full URL of the uploaded file instead of just the filename.
- [x] Ensured that the attachment.link field in the database now stores this full URL upon upload or update.
<img width="722" alt="Screenshot 2025-04-24 at 11 07 20" src="https://github.com/user-attachments/assets/21198ece-bba0-4796-8159-b00c1f1902d9" />

- [x] Fixed failing tests