### PR TITLE
Add isAbleToSendReview filed to Cooperation Aggregation

### DIFF
--- a/src/controllers/cooperation.js
+++ b/src/controllers/cooperation.js
@@ -11,9 +11,9 @@ const getCooperations = async (req, res) => {
 
 const getCooperationById = async (req, res) => {
   const { id } = req.params
-  const { role: userRole } = req.user
+  const { role: userRole, id: userId } = req.user
 
-  const cooperation = await cooperationService.getCooperationById(id, userRole)
+  const cooperation = await cooperationService.getCooperationById(id, userRole, userId)
 
   res.status(200).json(cooperation)
 }

--- a/src/services/cooperation.js
+++ b/src/services/cooperation.js
@@ -28,10 +28,10 @@ const cooperationService = {
     return result
   },
 
-  getCooperationById: async (id, userRole) => {
+  getCooperationById: async (id, userRole, userId) => {
     const isClosedResourcesHidden = userRole === roles.STUDENT
 
-    const pipeline = getCooperationByIdQueryPipeline(id, isClosedResourcesHidden)
+    const pipeline = getCooperationByIdQueryPipeline(id, isClosedResourcesHidden, userId)
 
     const [cooperationById] = await Cooperation.aggregate(pipeline)
 

--- a/src/utils/cooperations/getCooperationByIdQueryPipeline.js
+++ b/src/utils/cooperations/getCooperationByIdQueryPipeline.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose')
 const { DEFAULT_AGGREGATION_UNSELECTABLE_USER_FIELDS } = require('~/consts/user')
 
-const getCooperationByIdQueryPipeline = (id, isClosedResourcesHidden) => {
+const getCooperationByIdQueryPipeline = (id, isClosedResourcesHidden, userId) => {
   const filterOnlyOpenResources = {
     sections: {
       $map: {
@@ -383,13 +383,40 @@ const getCooperationByIdQueryPipeline = (id, isClosedResourcesHidden) => {
       }
     },
     {
+      $lookup: {
+        from: 'reviews',
+        let: {
+          offerId: '$offer._id',
+          userId: mongoose.Types.ObjectId(userId)
+        },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [{ $eq: ['$offer', '$$offerId'] }, { $eq: ['$author', '$$userId'] }]
+              }
+            }
+          }
+        ],
+        as: 'currentUserReviews'
+      }
+    },
+    {
+      $set: {
+        isAbleToSendReview: {
+          $eq: [{ $size: '$currentUserReviews' }, 0]
+        }
+      }
+    },
+    {
       $project: {
         initiator: DEFAULT_AGGREGATION_UNSELECTABLE_USER_FIELDS,
         receiver: DEFAULT_AGGREGATION_UNSELECTABLE_USER_FIELDS,
         'sections.resources.resource': {
           createdAt: false,
           updatedAt: false
-        }
+        },
+        currentUserReviews: false
       }
     }
   ]


### PR DESCRIPTION
Include a `isAbleToSendReview` field in each cooperation document to determine whether the current user is eligible to submit a review.


1. Performed a `$lookup` to the `reviews` collection using a custom pipeline to match:

- The current cooperation’s offer (`offer` field).

- The current user's ID (`userId`).

2. Stored matched reviews in a `userReview` array.

3. Used `$addFields` to add a boolean `isAbleToSendReview`:

- `true` if `userReview` is empty (user hasn’t reviewed this offer yet).

- `false` otherwise.

Now, when cooperation data is returned, it includes the `isAbleToSendReview` field indicating the user's ability to submit a review.
<img width="318" alt="Screenshot 2025-04-24 at 10 52 38" src="https://github.com/user-attachments/assets/4f5ae9c9-e07c-453c-8dca-b26c6525119c" />

