### PR TITLE
Update prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "jest-sonar-reporter": "^2.0.0",
         "lint-staged": "^15.5.0",
         "nodemon": "^3.1.9",
-        "prettier": "2.5.1",
+        "prettier": "^3.3.3",
         "supertest": "^6.2.4"
       }
     },
@@ -8820,15 +8820,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jest-sonar-reporter": "^2.0.0",
     "lint-staged": "^15.5.0",
     "nodemon": "^3.1.9",
-    "prettier": "2.5.1",
+    "prettier": "^3.3.3",
     "supertest": "^6.2.4"
   },
   "dependencies": {


### PR DESCRIPTION
- [x] Update `prettier` from `v2.5.1` to `v3.3.3`

# Breaking Changes:
- Node.js Version: Minimum required version is now v14.
- Public APIs: All public APIs are now asynchronous.
- Default Value Change: trailingComma default value changed to "all".
![image](https://github.com/user-attachments/assets/157b7f04-f222-47ff-a9cd-519371043374)

### Plugin System:
- Embed method of a printer has a new signature.
- Parsers.parse no longer accepts the second argument.
- Prettier.doc.builders.concat has been removed.
- TextToDoc now trims trailing hard lines.
- Package File Structure: Updated, with an exports field added to package.json (specific to 3.0.0-alpha.1).

Full changelog [here](https://github.com/prettier/prettier/blob/main/CHANGELOG.md#333)