### PR TITLE
Add removeConfirmToken after confirmEmail

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -119,6 +119,7 @@ const authService = {
     }
 
     await privateUpdateUser(_id, { isEmailConfirmed: true })
+    await tokenService.removeConfirmToken(confirmToken)
   },
 
   refreshAccessToken: async (refreshToken) => {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -7,7 +7,6 @@ const { createError } = require('~/utils/errorsHelper')
 const {
   EMAIL_ALREADY_CONFIRMED,
   EMAIL_NOT_CONFIRMED,
-  BAD_CONFIRM_TOKEN,
   INCORRECT_CREDENTIALS,
   BAD_RESET_TOKEN,
   BAD_REFRESH_TOKEN,
@@ -109,14 +108,10 @@ const authService = {
     const tokenFromDB = await tokenService.findToken(confirmToken, CONFIRM_TOKEN)
 
     if (!tokenFromDB || !tokenData) {
-      throw createError(400, BAD_CONFIRM_TOKEN)
-    }
-
-    const { _id, isEmailConfirmed } = await getUserById(tokenData.id)
-
-    if (isEmailConfirmed) {
       throw createError(400, EMAIL_ALREADY_CONFIRMED)
     }
+
+    const _id = await getUserById(tokenData.id)
 
     await privateUpdateUser(_id, { isEmailConfirmed: true })
     await tokenService.removeConfirmToken(confirmToken)

--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -127,12 +127,6 @@ describe('Auth controller', () => {
 
       expectError(400, errors.EMAIL_ALREADY_CONFIRMED, response)
     })
-
-    it('should throw BAD_CONFIRM_TOKEN error', async () => {
-      const response = await app.get('/auth/confirm-email/invalid_token')
-
-      expectError(400, errors.BAD_CONFIRM_TOKEN, response)
-    })
   })
 
   describe('Login endpoint', () => {


### PR DESCRIPTION
I analyzed the problem in detail and here is the conclusion

**Whats a Problem ?:**

Problem in this task was related to that after few days new _icloud_ account will be deleted for now reason

**Really Problem:**

The main problem was not only with _icloud_ accounts but with _gmail_ too
Because i created two new accounts and after few days they was deleted from db
They are deleted by `removeUsersWithUnconfirmedEmail` cron

The reason why this cron deleting new accounts because after confirm email we not delete `confirmToken` from Token collection in db
That explains why we not see in deleted accounts , accounts that was creating by OAuth, because with this method we not creating `confirmToken` for user
And because of this after logout from account this account will not deleted in future, because during logout we deleted tokens of this user, so `confirmToken` deleted to and after new login we will have only `refreshToken` and no `confirmToken`

**Here you can see two accounts:**

- _icloud_

<img width="713" alt="Знімок екрана 2025-05-10 о 18 02 47" src="https://github.com/user-attachments/assets/b399e7df-1d2e-4240-bb69-9a8505d5c994" />

<img width="695" alt="Знімок екрана 2025-05-10 о 18 02 57" src="https://github.com/user-attachments/assets/5a25e3e8-34f1-4d20-82ff-dc21b6b6186e" />

- _gmail_

<img width="800" alt="Знімок екрана 2025-05-10 о 18 05 20" src="https://github.com/user-attachments/assets/405edf6f-a859-4e51-9c37-7845e35ebf50" />

<img width="646" alt="Знімок екрана 2025-05-10 о 18 05 35" src="https://github.com/user-attachments/assets/cbdfe8e4-63ce-4fe7-9bd2-e3b19f122b29" />
 
Than i was login to both account but only from _icloud_ logouted

**After some time cron see them as unauthorized via `confirmToken` but `JWT_CONFIRM_EXPIRES_IN` is long so not delete them yet, thats explain why they deleted after few days:**

https://github.com/user-attachments/assets/ecac880c-b018-4922-89ac-dddbaf970600

**And when token is expired he deleted them:**

https://github.com/user-attachments/assets/6f633039-6d8c-455b-b053-f955397142c2

**Result:**

Now after confirm password confirmToken token will be deleted
But for more sure i need wait few days

https://github.com/user-attachments/assets/c294a9c2-f263-4fba-9796-a6693104a68d

and yes it is veryyy big description for few changed lines in PR :)

