### PR TITLE
Update dotenv package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cors": "^2.8.5",
         "country-state-city": "^3.2.1",
         "cron": "^2.1.0",
-        "dotenv": "^10.0.0",
+        "dotenv": "^16.4.5",
         "email-templates": "^10.0.0",
         "express": "^4.21.2",
         "googleapis": "^105.0.0",
@@ -4466,11 +4466,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cors": "^2.8.5",
     "country-state-city": "^3.2.1",
     "cron": "^2.1.0",
-    "dotenv": "^10.0.0",
+    "dotenv": "^16.4.5",
     "email-templates": "^10.0.0",
     "express": "^4.21.2",
     "googleapis": "^105.0.0",


### PR DESCRIPTION
- [x] Update `dotenv` from `v10.0.0` to `v16.4.5`
### Breaking changes:
### 16.0.0
- Added support for backticks. Need to wrap values containing the backtick character  in either single or double quotes.
### 15.0.0
- Multiline parsing support added, now works without a flag.
- `#` now marks the beginning of a comment, unless the value is wrapped in quotes. Need to wrap in quotes any values containing `#` in .env files.
- Removed the multiline option as it is now handled automatically.
### 14.0.0
- Added support for inline comments in the parser.
### 13.0.0
- Added a type file for `config.js`.
### 12.0.0
- Dropped support for Flow static type checker.
### 11.0.0
- Dropped support for Node v10.

Full changelog you can find [here](https://github.com/motdotla/dotenv/blob/master/CHANGELOG.md#1600-2022-02-02)